### PR TITLE
zabbix_host: fix wrong macro name

### DIFF
--- a/roles/zabbix_host/tasks/main.yml
+++ b/roles/zabbix_host/tasks/main.yml
@@ -143,7 +143,7 @@
     macro_value: "{{ zabbix_host_mariadb_username }}"
   when: "'mariadb' in group_names"
 
-- name: Create MYSQL_PASSWORD macro
+- name: Create MYSQL_PASS macro
   no_log: true
   local_action:
     module: community.zabbix.zabbix_hostmacro
@@ -152,7 +152,7 @@
     login_password: "{{ zabbix_login_password }}"
     state: present
     host_name: "{{ zabbix_host_host_name }}"
-    macro_name: "{$MYSQL_PASSWORD}"
+    macro_name: "{$MYSQL_PASS}"
     macro_value: "{{ zabbix_host_mariadb_password }}"
   when: "'mariadb' in group_names"
 


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>