### PR TITLE
systohc: add systohc argument

### DIFF
--- a/roles/systohc/defaults/main.yml
+++ b/roles/systohc/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+systohc: true
+systohc_common: "{{ systohc }}"

--- a/roles/systohc/tasks/main.yml
+++ b/roles/systohc/tasks/main.yml
@@ -3,3 +3,4 @@
   become: true
   command: hwclock --systohc
   changed_when: false
+  when: systohc|bool


### PR DESCRIPTION
With the systohc argument it is possible to disable the role.

Signed-off-by: Christian Berendt <berendt@osism.tech>