### PR TITLE
changed osism.de to osism.tech

### DIFF
--- a/.github/templates/galaxy.yml.j2
+++ b/.github/templates/galaxy.yml.j2
@@ -11,6 +11,6 @@ tags:
   - system
 dependencies: {}
 repository: https://github.com/osism/ansible-collection-commons.git
-documentation: https://docs.osism.de
-homepage: https://osism.de
+documentation: https://docs.osism.tech
+homepage: https://osism.tech
 issues: https://github.com/osism/ansible-collection-commons/issues


### PR DESCRIPTION
Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
