### PR TITLE
network: fix dict2items requires a dictionary

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -115,7 +115,7 @@ network_vlans: {}
 
 network_dispatcher_package_name: networkd-dispatcher
 network_dispatcher_service_name: networkd-dispatcher
-network_dispatcher_scripts: {}
+network_dispatcher_scripts: []
 
 # network_dispatcher_scripts:
 #   - src: /opt/configuration/network/vxlan.sh

--- a/roles/network/tasks/type-netplan.yml
+++ b/roles/network/tasks/type-netplan.yml
@@ -74,7 +74,7 @@
     mode: 0755
     owner: root
     group: root
-  loop: "{{ network_dispatcher_scripts|dict2items }}"
+  loop: "{{ network_dispatcher_scripts }}"
 
 - name: Wait for apt lock
   shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"


### PR DESCRIPTION
9521bf66597fae2ec556a437010796925c2cda4e was the wrong approach.

Closes #222

Signed-off-by: Christian Berendt <berendt@osism.tech>