### PR TITLE
renaming ansible builtin modules in the ansible-collections-commons/molecule/delegated Repository

### DIFF
--- a/molecule/delegated/converge.yml
+++ b/molecule/delegated/converge.yml
@@ -4,9 +4,9 @@
 
   tasks:
     - name: Include required variables
-      include_vars:
+      ansible.builtin.include_vars:
         file: "vars/{{ molecule_role }}.yml"
 
     - name: "Include {{ molecule_role }} role"
-      include_role:
+      ansible.builtin.include_role:
         name: "{{ molecule_role }}"

--- a/molecule/delegated/prepare.yml
+++ b/molecule/delegated/prepare.yml
@@ -4,5 +4,5 @@
 
   tasks:
     - name: Include required prepare tasks
-      include_tasks:
+      ansible.builtin.include_tasks:
         file: "prepare/{{ molecule_role }}.yml"


### PR DESCRIPTION
partly: osism/issues#63

﻿Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
