### PR TITLE
Use ansible.builtin.tasks

### DIFF
--- a/roles/configfs/tasks/main.yml
+++ b/roles/configfs/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Start sys-kernel-config mount
   become: true
-  service:
+  ansible.builtin.service:
     name: sys-kernel-config.mount
     state: started
     enabled: true


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commons/roles/configfs Repo.
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
