### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/facts/tasks/main.yml
+++ b/roles/facts/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create custom facts directory
   become: true
-  file:
+  ansible.builtin.file:
     path: /etc/ansible/facts.d
     state: "directory"
     owner: root
@@ -10,7 +10,7 @@
 
 - name: Copy fact files
   become: true
-  copy:
+  ansible.builtin.copy:
     src: "{{ item }}.fact"
     dest: "/etc/ansible/facts.d/{{ item }}.fact"
     owner: root


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/facts Repo.
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
