### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/firewall/handlers/main.yml
+++ b/roles/firewall/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Restart {{ ufw_service_name }} service"
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ ufw_service_name }}"
     state: restarted

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy ufw.conf configuration file
   become: true
-  template:
+  ansible.builtin.template:
     src: ufw.conf.j2
     dest: /etc/ufw/ufw.conf
     mode: 0644
@@ -9,7 +9,7 @@
 
 - name: "Start {{ ufw_service_name }} service"
   become: true
-  service:
+  ansible.builtin.service:
     name: "{{ ufw_service_name }}"
     state: started
     enabled: true


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/firewall
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
