### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/hostname/tasks/main.yml
+++ b/roles/hostname/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Set hostname
   become: true
-  hostname:
+  ansible.builtin.hostname:
     name: "{{ inventory_hostname_short }}"
 
 - name: Copy /etc/hostname
   become: true
-  copy:
+  ansible.builtin.copy:
     content: "{{ inventory_hostname_short }}{{ '\n' }}"
     dest: /etc/hostname
     owner: root


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/hostname
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
