### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Include type specific tasks
-  include: "type-{{ hosts_type }}.yml"
+  ansible.builtin.include: "type-{{ hosts_type }}.yml"

--- a/roles/hosts/tasks/type-block.yml
+++ b/roles/hosts/tasks/type-block.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get /etc/hosts file
-  slurp:
+  ansible.builtin.slurp:
     src: "{{ hosts_file }}"
   register: hosts
 
 - name: Copy initial /etc/hosts file
   become: true
-  template:
+  ansible.builtin.template:
     src: "hosts-block.j2"
     dest: "{{ hosts_file }}"
     owner: root
@@ -17,7 +17,7 @@
 
 - name: Add hosts
   become: true
-  blockinfile:
+  ansible.builtin.blockinfile:
     dest: "{{ hosts_file }}"
     block: |
       {{ hostvars[item]['ansible_' + hostvars[item]['hosts_interface']]['ipv4']['address'] }} {{ item }} {{ item.split('.')[0] }}
@@ -32,7 +32,7 @@
 
 - name: Add additional hosts
   become: true
-  blockinfile:
+  ansible.builtin.blockinfile:
     dest: "{{ hosts_file }}"
     block: |
       {{ item.1 }} {{ item.0 }} {{ item.0.split('.')[0] }}

--- a/roles/hosts/tasks/type-local.yml
+++ b/roles/hosts/tasks/type-local.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create temporary file
-  tempfile:
+  ansible.builtin.tempfile:
     state: file
     suffix: hosts
   register: hosts_tempfile
@@ -8,7 +8,7 @@
   run_once: true
 
 - name: Generate temporary /etc/hosts file
-  template:
+  ansible.builtin.template:
     src: "hosts-template.j2"
     dest: "{{ hosts_tempfile.path }}"
     mode: 0644
@@ -17,7 +17,7 @@
 
 - name: Copy /etc/hosts file
   become: true
-  copy:
+  ansible.builtin.copy:
     src: "{{ hosts_tempfile.path }}"
     dest: "{{ hosts_file }}"
     owner: root
@@ -26,7 +26,7 @@
     backup: "{{ hosts_file_backup }}"
 
 - name: Delete temporary file
-  file:
+  ansible.builtin.file:
     path: "{{ hosts_tempfile.path }}"
     state: absent
   delegate_to: localhost

--- a/roles/hosts/tasks/type-template.yml
+++ b/roles/hosts/tasks/type-template.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copy /etc/hosts file
   become: true
-  template:
+  ansible.builtin.template:
     src: "hosts-template.j2"
     dest: "{{ hosts_file }}"
     owner: root


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/hosts
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
