### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/ipmitool/tasks/install-Debian.yml
+++ b/roles/ipmitool/tasks/install-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -8,6 +8,6 @@
 
 - name: Install ipmitool package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ ipmitool_package_name }}"
     state: present

--- a/roles/ipmitool/tasks/main.yml
+++ b/roles/ipmitool/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 - name: Include distribution specific install tasks
-  include: "install-{{ ansible_os_family }}.yml"
+  ansible.builtin.include: "install-{{ ansible_os_family }}.yml"
 
 - name: Persist kernel modules via modules-load.d
   become: true
-  template:
+  ansible.builtin.template:
     src: module-load.conf.j2
     dest: "/etc/modules-load.d/{{ item }}.conf"
   loop: "{{ ipmitool_kernel_modules }}"
 
 - name: Load required kernel modules
   become: true
-  modprobe:
+  community.general.modprobe:
     name: "{{ item }}"
     state: present
   loop: "{{ ipmitool_kernel_modules }}"


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/ipmitool
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
