### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/kernel_modules/tasks/main.yml
+++ b/roles/kernel_modules/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Enable kernel modules
   become: true
-  lineinfile:
+  ansible.builtin.lineinfile:
     line: "{{ item }}"
     dest: /etc/modules
     mode: 0644
@@ -10,7 +10,7 @@
 
 - name: Load kernel module
   become: true
-  modprobe:
+  community.general.modprobe:
     name: "{{ item }}"
     state: present
   loop: "{{ kernel_modules }}"


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/kernel_modules
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
