### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/kompose/tasks/install-url.yml
+++ b/roles/kompose/tasks/install-url.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -8,13 +8,13 @@
 
 - name: Ensure kompose is not installed
   become: true
-  apt:
+  ansible.builtin.apt:
     name: kompose
     state: absent
 
 - name: Block installation of kompose package
   become: true
-  copy:
+  ansible.builtin.copy:
     content: |
       Package: kompose
       Pin: version *
@@ -24,7 +24,7 @@
 
 - name: Download kompose binary
   become: true
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ kompose_url }}"
     dest: /usr/local/bin/kompose
     owner: root
@@ -32,13 +32,13 @@
     mode: 0755
 
 - name: Get checksum of kompose binary
-  stat:
+  ansible.builtin.stat:
     path: /usr/local/bin/kompose
     checksum_algorithm: sha256
   register: p
 
 - name: Check checksum of kompose binary
-  fail:
+  ansible.builtin.fail:
     msg: "Expected checksum of kompose does not match"
   when:
     - "p.stat.checksum != kompose_checksum"

--- a/roles/kompose/tasks/main.yml
+++ b/roles/kompose/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Include install type specific tasks
-  include: "install-{{ kompose_install_type }}.yml"
+  ansible.builtin.include: "install-{{ kompose_install_type }}.yml"


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/kompose
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
