### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/microcode/tasks/main.yml
+++ b/roles/microcode/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for apt lock
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -8,6 +8,6 @@
 
 - name: Install microcode packages
   become: true
-  apt:
+  ansible.builtin.apt:
     name: "{{ microcode_packages }}"
     state: present


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/microcode
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
