### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/motd/tasks/configure-Debian.yml
+++ b/roles/motd/tasks/configure-Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for apt lock
   become: true
-  shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
   loop:
     - lock
     - lock-frontend
@@ -9,13 +9,13 @@
 
 - name: Remove update-motd package
   become: true
-  apt:
+  ansible.builtin.apt:
     name: update-motd
     state: absent
 
 - name: Stop motd-news timer
   become: true
-  service:
+  ansible.builtin.service:
     name: motd-news.timer
     state: stopped
     enabled: false
@@ -23,7 +23,7 @@
 
 - name: Stop motd-news service
   become: true
-  service:
+  ansible.builtin.service:
     name: motd-news.service
     state: stopped
     enabled: false
@@ -31,7 +31,7 @@
 
 - name: Disable dynamic motd banner in pam configuration for ssh
   become: true
-  replace:
+  ansible.builtin.replace:
     path: /etc/pam.d/sshd
     regexp: "{{ item.regex }}"
     replace: "{{ item.replace }}"
@@ -46,7 +46,7 @@
 
 - name: Disable dynamic motd banner in pam configuration for login
   become: true
-  replace:
+  ansible.builtin.replace:
     path: /etc/pam.d/login
     regexp: "{{ item.regex }}"
     replace: "{{ item.replace }}"

--- a/roles/motd/tasks/configure-RedHat.yml
+++ b/roles/motd/tasks/configure-RedHat.yml
@@ -1,2 +1,2 @@
 ---
-# there are no tasks to to, but the include needs a file
+# there are no tasks to do, but the include needs a file

--- a/roles/motd/tasks/main.yml
+++ b/roles/motd/tasks/main.yml
@@ -3,11 +3,11 @@
   scan_services:
 
 - name: Include distribution specific configure tasks
-  include_tasks: "configure-{{ ansible_os_family }}.yml"
+  ansible.builtin.include_tasks: "configure-{{ ansible_os_family }}.yml"
 
 - name: Copy motd file
   become: true
-  copy:
+  ansible.builtin.copy:
     content: "{{ motd_content }}"
     dest: "{{ motd_path }}"
     owner: root


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/motd Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
