### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/proxy/tasks/Debian.yml
+++ b/roles/proxy/tasks/Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure proxy parameters for apt
   become: true
-  template:
+  ansible.builtin.template:
     src: proxy-apt.j2
     dest: "{{ proxy_apt_conf_path }}"
     owner: root

--- a/roles/proxy/tasks/RedHat.yml
+++ b/roles/proxy/tasks/RedHat.yml
@@ -1,7 +1,7 @@
 ---
 - name: Disable fastmirror plugin
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/yum/pluginconf.d/fastestmirror.conf
     section: main
     option: enabled
@@ -10,7 +10,7 @@
 
 - name: Configure proxy parameters for yum
   become: true
-  ini_file:
+  community.general.ini_file:
     path: /etc/yum.conf
     section: main
     option: proxy

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Include distribution specific tasks
-  include: "{{ ansible_os_family }}.yml"
+  ansible.builtin.include: "{{ ansible_os_family }}.yml"
   when:
     - proxy_package_manager|bool
     - proxy_proxies != {}
 
 - name: Set system wide settings in environment file
   become: true
-  blockinfile:
+  ansible.builtin.blockinfile:
     dest: /etc/environment
     marker: "# {mark} ANSIBLE MANAGED BLOCK (osism.proxy)"
     block: |


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/proxy Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
