### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/resolvconf/tasks/configure-resolv.yml
+++ b/roles/resolvconf/tasks/configure-resolv.yml
@@ -1,7 +1,7 @@
 ---
 - name: Stopp/disable resolvconf service
   become: true
-  service:
+  ansible.builtin.service:
     name: resolvconf
     state: stopped
     enabled: false
@@ -9,13 +9,13 @@
   failed_when: "result is failed and ('find' not in result.msg and 'found' not in result.msg)"
 
 - name: "Retrieve {{ resolvconf_file }} file status"
-  stat:
+  ansible.builtin.stat:
     path: "{{ resolvconf_file }}"
   register: stat_resolvconf_file
 
 - name: "Archive existing {{ resolvconf_file }} file"
   become: true
-  synchronize:
+  ansible.posix.synchronize:
     src: "/etc/resolv.conf"
     dest: "/etc/resolv.conf.{{ ansible_date_time.date }}"
     archive: true
@@ -24,7 +24,7 @@
 
 - name: Copy configuration files
   become: true
-  template:
+  ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     owner: root
@@ -38,14 +38,14 @@
 - name: Restart systemd-resolved service
   become: true
   when: resolved_conf.changed  # noqa 503
-  systemd:
+  ansible.builtin.systemd:
     name: systemd-resolved
     daemon_reload: true
     state: restarted
 
 - name: "Link {{ resolvconf_file }} to /run/systemd/resolve/stub-resolv.conf"
   become: true
-  file:
+  ansible.builtin.file:
     src: /run/systemd/resolve/stub-resolv.conf
     dest: "{{ resolvconf_file }}"
     state: link

--- a/roles/resolvconf/tasks/main.yml
+++ b/roles/resolvconf/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check minimum number of name servers
-  fail:
+  ansible.builtin.fail:
     msg: |
       {{ resolvconf_minimum_number_of_nameservers }} or more name servers
       must be configured. Currently only {{ resolvconf_nameserver|length }}
@@ -8,5 +8,5 @@
   when: resolvconf_nameserver|length < resolvconf_minimum_number_of_nameservers|int
 
 - name: Include resolvconf tasks
-  include: "configure-resolv.yml"
+  ansible.builtin.include: "configure-resolv.yml"
   when: resolvconf_nameserver|length > 0


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/resolvconf Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
