### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/state/tasks/main.yml
+++ b/roles/state/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create custom facts directory
   become: true
-  file:
+  ansible.builtin.file:
     path: /etc/ansible/facts.d
     state: "directory"
     owner: root


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/state Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
