### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/sysctl/tasks/main.yml
+++ b/roles/sysctl/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Include sysctl tasks
-  include: sysctl.yml
+  ansible.builtin.include: sysctl.yml
   loop: "{{ sysctl|dict2items }}"

--- a/roles/sysctl/tasks/sysctl.yml
+++ b/roles/sysctl/tasks/sysctl.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Set sysctl parameters on {{ item }} nodes"
   become: true
-  sysctl:
+  ansible.posix.sysctl:
     name: "{{ item_in_block.name }}"
     value: "{{ item_in_block.value }}"
     sysctl_set: true


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/sysctl Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
