### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/systohc/tasks/main.yml
+++ b/roles/systohc/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Sync hardware clock
   become: true
-  command: hwclock --systohc
+  ansible.buitlin.command: hwclock --systohc
   changed_when: false
   when: systohc|bool


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-commes/roles/systohc Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
