### PR TITLE
sysctl: allow configuration of extra parameters

### DIFF
--- a/roles/sysctl/defaults/main.yml
+++ b/roles/sysctl/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-sysctl:
+sysctl_defaults:
   elasticsearch:
     # https://github.com/docker-library/elasticsearch/issues/98
     - name: vm.max_map_count
@@ -28,3 +28,5 @@ sysctl:
   all:
     - name: vm.swappiness
       value: 1
+
+sysctl_extra: {}

--- a/roles/sysctl/tasks/main.yml
+++ b/roles/sysctl/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Include sysctl tasks
   ansible.builtin.include_tasks: sysctl.yml
-  loop: "{{ sysctl|dict2items }}"
+  loop: "{{ sysctl_defaults|combine(sysctl_extra)|dict2items }}"


### PR DESCRIPTION
The existing sysctl parameter is renamed to sysctl_defaults
and combined with the new sysctl_extra parameter. This makes
it possible to set additional parameters for specific host
groups via sysctl_extra.

Closes #277

Signed-off-by: Christian Berendt <berendt@osism.tech>