### PR TITLE
configuration: use include_tasks

### DIFF
--- a/roles/configuration/tasks/main.yml
+++ b/roles/configuration/tasks/main.yml
@@ -11,4 +11,4 @@
     - "{{ configuration_directory }}"
 
 - name: Include tasks required by the specific configuration type
-  include: "{{ configuration_type }}.yml"
+  include_tasks: "{{ configuration_type }}.yml"


### PR DESCRIPTION
This will resolve the following deprecation note:

[DEPRECATION WARNING]: "include" is deprecated, use
include_tasks/import_tasks/import_playbook instead. This feature will be
removed in version 2.16. Deprecation warnings can be disabled by setting

Signed-off-by: Christian Berendt <berendt@osism.tech>