### PR TITLE
with standard ubuntu value of nf_conntrack_max we are reaching the limit

### DIFF
--- a/roles/sysctl/defaults/main.yml
+++ b/roles/sysctl/defaults/main.yml
@@ -28,5 +28,8 @@ sysctl_defaults:
   all:
     - name: vm.swappiness
       value: 1
+  compute:
+    - name: net.netfilter.nf_conntrack_max
+      value: 1048576
 
 sysctl_extra: {}


### PR DESCRIPTION
really often so we would like to have a much higher limit as standard
in osism installations

Signed-off-by: Markus Lindenblatt <markus.lindenblatt@plusserver.com>