### PR TITLE
sysctl: ignore errors about unknown keys

### DIFF
--- a/roles/sysctl/tasks/sysctl.yml
+++ b/roles/sysctl/tasks/sysctl.yml
@@ -6,6 +6,7 @@
     value: "{{ item_in_block.value }}"
     sysctl_set: true
     sysctl_file: "/etc/sysctl.d/70-{{ item.key }}.conf"
+    ignoreerrors: true
   loop: "{{ item.value }}"
   loop_control:
     loop_var: item_in_block


### PR DESCRIPTION
Some of the defaults only work on certain systems. Therefore,
ignore them if they cannot be set.

setting net.netfilter.nf_conntrack_max failed: sysctl: cannot
stat /proc/sys/net/netfilter/nf_conntrack_max: No such file or
directory

Signed-off-by: Christian Berendt <berendt@osism.tech>