### PR TITLE
sysctl: fix task name

### DIFF
--- a/roles/sysctl/tasks/sysctl.yml
+++ b/roles/sysctl/tasks/sysctl.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Set sysctl parameters on {{ item }} nodes"
+- name: "Set sysctl parameters on {{ item.key }} nodes"
   become: true
   ansible.posix.sysctl:
     name: "{{ item_in_block.name }}"


### PR DESCRIPTION
This will fix the following issue:

TASK [osism.commons.sysctl : Set sysctl parameters on {'key':
'elasticsearch', 'value': [{'name': 'vm.max_map_count', 'value':
262144}]} nodes] ***

Signed-off-by: Christian Berendt <berendt@osism.tech>