### PR TITLE
Fix hosts_interface variable evaluation

### DIFF
--- a/roles/hosts/defaults/main.yml
+++ b/roles/hosts/defaults/main.yml
@@ -5,7 +5,7 @@ hosts_enable: true
 
 # The IPv4 address assigned to this interface is placed in the
 # hosts file.
-hosts_interface: "{{ management_interface|default('lo') }}"
+# hosts_interface:
 
 # Write only hosts that are included in this group to the
 # hosts file.

--- a/roles/hosts/templates/hosts-template.j2
+++ b/roles/hosts/templates/hosts-template.j2
@@ -14,8 +14,13 @@ ff02::2          ip6-allrouters
 # Hosts defined in the inventory
 
 {% for item in groups[hosts_group_name]|default([])|sort %}
-{% if item not in hosts_ignore and hostvars[item] is defined and hostvars[item]['ansible_' + hostvars[item]['hosts_interface']|default(hosts_interface)] is defined and hostvars[item]['hosts_enable']|default(hosts_enable)|bool %}
-{{ hostvars[item]['ansible_' + hostvars[item]['hosts_interface']|default(hosts_interface)]['ipv4']['address'] }} {{ item }} {{ item.split('.')[0] }}
+{% if item not in hosts_ignore and hostvars[item] is defined and hostvars[item]['hosts_enable']|default(hosts_enable)|bool %}
+{% if hostvars[item]['hosts_interface'] is defined %}
+{% set hosts_interface = hostvars[item]['hosts_interface'] %}
+{% else %}
+{% set hosts_interface = hostvars[item]['management_interface']|default('lo') %}
+{% endif %}
+{{ hostvars[item]['ansible_' + hosts_interface]['ipv4']['address'] }} {{ item }} {{ item.split('.')[0] }}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Defining hosts_interface variable in defaults.yml is not working
correctly. The variable needs to be evaluated in the for loop to
retrieve the correct interface name of the current host.