### PR TITLE
motd: use an empty string by default for the /etc/motd

### DIFF
--- a/roles/motd/defaults/main.yml
+++ b/roles/motd/defaults/main.yml
@@ -1,9 +1,3 @@
 ---
 motd_path: /etc/motd
-motd_content: |
-  ------------------------------------------------------------------------------
-  * WARNING                                                                    *
-  * You are accessing a secured system and your actions will be logged along   *
-  * with identifying information. Disconnect immediately if you are not an     *
-  * authorized user of this system.                                            *
-  ------------------------------------------------------------------------------
+motd_content: ""


### PR DESCRIPTION
The previous default note was there by default because
of STIG V-71859. On environments where this is needed,
the value can be set explicitly.

Closes #296

Signed-off-by: Christian Berendt <berendt@osism.tech>