### PR TITLE
configuration: support proxy configuration

### DIFF
--- a/roles/configuration/defaults/main.yml
+++ b/roles/configuration/defaults/main.yml
@@ -21,6 +21,8 @@ configuration_directory: /opt/configuration
 
 configuration_git_package_name: git
 
+configuration_git_proxy: ""
+
 configuration_git_public_key: ""
 configuration_git_private_key: ""
 configuration_git_private_key_file: ~/.ssh/id_rsa.configuration

--- a/roles/configuration/tasks/git.yml
+++ b/roles/configuration/tasks/git.yml
@@ -32,6 +32,13 @@
     name: "{{ configuration_git_package_name }}"
     state: present
 
+- name: git - set proxy configuration
+  community.general.git_config:
+    name: http.proxy
+    scope: global
+    value: "{{ configuration_git_proxy }}"
+  when: configuration_git_proxy is defined and configuration_git_proxy|length
+
 - name: git - clone configuration repository (ssh / with auth)
   git:
     repo: "{{ configuration_git_repository_url }}"


### PR DESCRIPTION
With the configuration_git_proxy argument it is possible
to set the HTTP proxy configuration for Git.

Signed-off-by: Christian Berendt <berendt@osism.tech>