### PR TITLE
Replace deprecated local_action

### DIFF
--- a/roles/network/tasks/type-netplan.yml
+++ b/roles/network/tasks/type-netplan.yml
@@ -35,11 +35,11 @@
 #       the use of variables as keys in the dictionaries.
 
 - name: Prepare netplan configuration template
-  local_action:  # noqa deprecated-local-action
-    module: ansible.builtin.template
+  ansible.builtin.template:
     src: netplan/01-osism.yaml.j2
     dest: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
     mode: 0644
+  delegate_to: localhost
 
 - name: Copy netplan configuration
   become: true
@@ -53,10 +53,10 @@
     - Netplan configuration changed
 
 - name: Remove netplan configuration template
-  local_action:  # noqa deprecated-local-action
-    module: ansible.builtin.file
+  ansible.builtin.file:
     path: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
     state: absent
+  delegate_to: localhost
 
 - name: Copy interfaces file
   become: true


### PR DESCRIPTION
- Change local_action to delegate_to and use the ansible FQCN.
- This closes #322

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>