### PR TITLE
repository: Use privilage escalation when checking for apt keys

### DIFF
--- a/roles/repository/tasks/repository-Debian.yml
+++ b/roles/repository/tasks/repository-Debian.yml
@@ -15,6 +15,7 @@
   loop: "{{ repository_key_ids|dict2items }}"
 
 - name: Check if the keys directory exists
+  become: true
   ansible.builtin.stat:
     path: "{{ repository_key_files_directory }}"
   register: result


### PR DESCRIPTION
Privilage escalation is needed. Otherwise:

```
TASK [osism.commons.repository : Check if the keys directory exists] *****************************************************************************************************
fatal: [manager1 -> localhost]: FAILED! => {"changed": false, "msg": "Permission denied"}
```