### PR TITLE
cleanup: remove cloudinit

### DIFF
--- a/roles/cleanup/defaults/main.yml
+++ b/roles/cleanup/defaults/main.yml
@@ -7,3 +7,5 @@ cleanup_packages: "{{ cleanup_packages_default + cleanup_packages_extra + cleanu
 cleanup_services_default: []
 cleanup_services_extra: []
 cleanup_services: "{{ cleanup_services_default + cleanup_services_extra + cleanup_services_distribution }}"
+
+cleanup_cloudinit: true

--- a/roles/cleanup/tasks/cloudinit.yml
+++ b/roles/cleanup/tasks/cloudinit.yml
@@ -1,0 +1,6 @@
+---
+- name: Remove cloud-init configuration directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/cloud
+    state: absent

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -10,3 +10,7 @@
 
 - name: Include packages tasks
   ansible.builtin.include_tasks: "packages-{{ ansible_os_family }}.yml"
+
+- name: Include cloudinit tasks
+  ansible.builtin.include_tasks: cloudinit.yml
+  when: cleanup_cloudinit|bool

--- a/roles/cleanup/tasks/packages-Debian.yml
+++ b/roles/cleanup/tasks/packages-Debian.yml
@@ -20,6 +20,21 @@
     - lock-frontend
   changed_when: false
 
+- name: Remove cloudinit package
+  become: true
+  ansible.builtin.apt:
+    name: "{{ cleanup_cloudinit_package_name }}"
+    state: absent
+    purge: true
+  when: cleanup_cloudinit|bool
+
+- name: Wait for apt lock
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  loop:
+    - lock
+    - lock-frontend
+  changed_when: false
+
 - name: Uninstall unattended-upgrades package
   become: true
   ansible.builtin.apt:

--- a/roles/cleanup/tasks/packages-RedHat.yml
+++ b/roles/cleanup/tasks/packages-RedHat.yml
@@ -5,6 +5,13 @@
     name: "{{ cleanup_packages }}"
     state: absent
 
+- name: Remove cloudinit package
+  become: true
+  ansible.builtin.dnf:
+    name: "{{ cleanup_cloudinit_package_name }}"
+    state: absent
+  when: cleanup_cloudinit|bool
+
 - name: Remove useless packages from the cache
   become: true
   ansible.builtin.command:

--- a/roles/cleanup/vars/Debian.yml
+++ b/roles/cleanup/vars/Debian.yml
@@ -4,3 +4,5 @@ cleanup_packages_distribution:
   - libvirt-bin
   - lxd
   - open-iscsi
+
+cleanup_cloudinit_package_name: cloud-init

--- a/roles/cleanup/vars/RedHat.yml
+++ b/roles/cleanup/vars/RedHat.yml
@@ -3,3 +3,5 @@ cleanup_services_distribution: []
 cleanup_packages_distribution:
   - libvirt
   - iscsi-initiator-utils
+
+cleanup_cloudinit_package_name: cloud-init


### PR DESCRIPTION
Depending on how virtual systems or baremetal was deployed cloud-init
is present there. This can break things on a second boot.

Therefore, cloudinit will be removed by default from now on.

Any cloud-init logs that may exist are not removed.

Closes osism/issues#213

Signed-off-by: Christian Berendt <berendt@osism.tech>