### PR TITLE
feature/add missing variable documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -57,4 +57,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: sysctl
 
+.. zuul:autorole:: sysdig
+
 .. zuul:autorole:: systohc

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -50,3 +50,5 @@ ansible-collections-commons
 .. zuul:autorole:: services
 
 .. zuul:autorole:: sosreport
+
+.. zuul:autorole:: sshconfig

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -21,4 +21,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: ipmitool
 
+.. zuul:autorole:: kernel_modules
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -56,3 +56,5 @@ ansible-collections-commons
 .. zuul:autorole:: state
 
 .. zuul:autorole:: sysctl
+
+.. zuul:autorole:: systohc

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -54,3 +54,5 @@ ansible-collections-commons
 .. zuul:autorole:: sshconfig
 
 .. zuul:autorole:: state
+
+.. zuul:autorole:: sysctl

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,6 +11,8 @@ ansible-collections-commons
 
 .. zuul:autorole:: docker_compose
 
+.. zuul:autorole:: facts
+
 .. zuul:autorole:: firewall
 
 .. zuul:autorole:: hostname

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -52,3 +52,5 @@ ansible-collections-commons
 .. zuul:autorole:: sosreport
 
 .. zuul:autorole:: sshconfig
+
+.. zuul:autorole:: state

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,4 +23,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: kernel_modules
 
+.. zuul:autorole:: known_hosts
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,4 +27,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: kompose
 
+.. zuul:autorole:: kubectl
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -34,3 +34,5 @@ ansible-collections-commons
 .. zuul:autorole:: microcode
 
 .. zuul:autorole:: motd
+
+.. zuul:autorole:: operator

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,4 +17,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: hostname
 
+.. zuul:autorole:: hosts
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,4 +19,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: hosts
 
+.. zuul:autorole:: ipmitool
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -29,4 +29,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: kubectl
 
+.. zuul:autorole:: lynis
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -38,3 +38,5 @@ ansible-collections-commons
 .. zuul:autorole:: operator
 
 .. zuul:autorole:: packages
+
+.. zuul:autorole:: podman

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -42,3 +42,5 @@ ansible-collections-commons
 .. zuul:autorole:: podman
 
 .. zuul:autorole:: proxy
+
+.. zuul:autorole:: repository

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -31,4 +31,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: lynis
 
+.. zuul:autorole:: microcode
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -48,3 +48,5 @@ ansible-collections-commons
 .. zuul:autorole:: resolvconf
 
 .. zuul:autorole:: services
+
+.. zuul:autorole:: sosreport

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,4 +13,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: firewall
 
+.. zuul:autorole:: hostname
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,6 +9,8 @@ ansible-collections-commons
 
 .. zuul:autorole:: configuration
 
+.. zuul:autorole:: docker_compose
+
 .. zuul:autorole:: firewall
 
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -46,3 +46,5 @@ ansible-collections-commons
 .. zuul:autorole:: repository
 
 .. zuul:autorole:: resolvconf
+
+.. zuul:autorole:: services

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -36,3 +36,5 @@ ansible-collections-commons
 .. zuul:autorole:: motd
 
 .. zuul:autorole:: operator
+
+.. zuul:autorole:: packages

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -40,3 +40,5 @@ ansible-collections-commons
 .. zuul:autorole:: packages
 
 .. zuul:autorole:: podman
+
+.. zuul:autorole:: proxy

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -25,4 +25,6 @@ ansible-collections-commons
 
 .. zuul:autorole:: known_hosts
 
+.. zuul:autorole:: kompose
+
 .. zuul:autorole:: motd

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -44,3 +44,5 @@ ansible-collections-commons
 .. zuul:autorole:: proxy
 
 .. zuul:autorole:: repository
+
+.. zuul:autorole:: resolvconf

--- a/roles/docker_compose/README.rst
+++ b/roles/docker_compose/README.rst
@@ -1,0 +1,29 @@
+Ansible role for configuration and installation of docker-compose including its components.
+
+**Role Variables**
+
+.. zuul:rolevar:: docker_compose_install_type
+   :default: package
+
+Source of docker-compose installation.
+Currently only 'package' is supported.
+
+.. zuul:rolevar:: docker_compose_package_name
+   :default: docker-compose
+
+The name of the docker-compose package to install.
+
+.. zuul:rolevar:: docker_compose_plugin_package_name
+   :default: docker-compose-plugin
+
+The name of the docker-compose-plugin package to install.
+
+.. zuul:rolevar:: docker_compose_service_user
+   :default: "{{ operator_user | default('dragon') }}"
+
+The user the docker-compose service should run with.
+
+.. zuul:rolevar:: docker_compose_service_group
+   :default: "{{ operator_group | default('dragon') }}"
+
+The group the docker-compose service should run with.

--- a/roles/facts/README.rst
+++ b/roles/facts/README.rst
@@ -1,0 +1,7 @@
+Install custom ansible facts.
+
+**Role Variables**
+
+.. zuul:rolevar:: fact_files
+
+List of facts to install.

--- a/roles/hostname/README.rst
+++ b/roles/hostname/README.rst
@@ -1,0 +1,2 @@
+Ansible role for setting up the hostname. It uses the short hostname 
+provided from the ansible inventory.

--- a/roles/hosts/README.rst
+++ b/roles/hosts/README.rst
@@ -1,0 +1,59 @@
+This role populates the ``/etc/hosts`` file with the hosts from the ansible
+inventory. For each host, if ``host_enable`` is ``true``, the IPv4 address
+of the ``hosts_interface`` is added to ``/etc/hosts``.
+
+**Role Variables**
+
+.. zuul:rolevar:: hosts_enable
+   :default: true
+
+Whether to include hosts by default.
+
+.. zuul:rolevar:: hosts_interface
+
+The IPv4 address assigned to this interface is placed in the hosts file.
+
+.. zuul:rolevar:: hosts_group_name
+   :default: all
+
+Write only hosts that are included in this group to the hosts file.
+
+.. zuul:rolevar:: hosts_use_dns_as_single_source_of_truth
+   :default: false
+
+Set this parameter to True if DNS is to be used as a single source of
+truth. No hosts from the hosts defined under hosts_group_name are then
+included in the hosts file.
+
+.. zuul:rolevar:: hosts_type
+   :default: block
+
+valid values: [block, local, template] # TODO
+
+.. zuul:rolevar:: hosts_file
+   :default: /etc/hosts
+
+Path to the managed hosts file.
+
+.. zuul:rolevar:: hosts_file_backup
+   :default: true
+
+If this value is set to true, a backup of the file is created before any
+changes are made.
+
+.. zuul:rolevar:: hosts_file_reset
+   :default: false
+
+If the type block is used and this value is set to True the hosts file is
+always completely reset.
+
+.. zuul:rolevar:: hosts_ignore
+   default: []
+
+A list of hosts that should not be included in the hosts file.
+
+.. zuul:rolevar:: hosts_additional_entries
+   :default: {}
+
+A dictionary with entries in the form FQDN: IP_ADDRESS which are added
+to the end of the hosts file.

--- a/roles/ipmitool/README.rst
+++ b/roles/ipmitool/README.rst
@@ -1,0 +1,14 @@
+Ansbile role for installing ipmitool and its required kernel modules.
+
+**Role Variables**
+
+.. zuul:rolevar:: ipmitool_package_name
+   :default: ipmitool
+
+Distribution package for ipmitool.
+
+.. zuul:rolevar:: ipmitool_kernel_modules
+   :default: - ipmi_devintf
+             - ipmi_si
+
+Required kernel modules for running ipmitool.

--- a/roles/kernel_modules/README.rst
+++ b/roles/kernel_modules/README.rst
@@ -1,0 +1,19 @@
+Ansible role for installing kernel modules.
+
+**Role Variables**
+
+.. zuul:rolevar:: kernel_modules_default
+   :default: - bonding
+             - 8021q
+
+Kernel modules which you want to install.
+
+.. zuul:rolevar:: kernel_modules_extra
+   :default: []
+
+Extra modules defiened in a list which you want to install.
+
+.. zuul:rolevar:: kernel_modules
+   :default: kernel_modules_default + kernel_modules_extra
+
+All modules which you want to install.

--- a/roles/known_hosts/README.rst
+++ b/roles/known_hosts/README.rst
@@ -1,0 +1,24 @@
+This role adds the ssh hostkeys from hosts in the ansible inventory
+to a known_hosts file.
+
+**Role Variables**
+
+.. zuul:rolevar:: operator_user
+   :default: dragon
+
+The user that will own the known_hosts file.
+
+.. zuul:rolevar:: operator_group
+   :default: operator_user
+
+The group that will own the known_hosts file.
+
+.. zuul:rolevar:: known_hosts_group_name
+   :default: all
+
+Add hosts from this group to known_hosts.
+
+.. zuul:rolevar:: known_hosts_destination
+   :default: /home/{{ operator_user }}/.ssh
+
+Destination where the known_hosts file is stored.

--- a/roles/kompose/README.rst
+++ b/roles/kompose/README.rst
@@ -1,0 +1,23 @@
+This ansible role checks if kompose is already installed, if not triggers an install and checks the checksum.
+
+**Role Variables**
+
+.. zuul:rolevar:: kompose_install_type
+   :default: url
+
+From which source the download should done.
+
+.. zuul:rolevar:: kompose_version
+   :default: 1.22.0
+
+Which version of kompose should be installed.
+
+.. zuul:rolevar:: kompose_checksum
+   :default: 6203d67263886bbd455168f59309496d486fc3a6df330b7ba37823b283bd9ea5
+
+The checksum of the downloaded file.
+
+.. zuul:rolevar:: kompose_url
+   :default: "https://github.com/kubernetes/kompose/releases/download/v{{ kompose_version }}/kompose-linux-amd64"
+
+Url for the download.

--- a/roles/kubectl/README.rst
+++ b/roles/kubectl/README.rst
@@ -1,0 +1,28 @@
+This ansible role will install kubectl
+
+**Role Variables**
+
+.. zuul:rolevar:: kubectl_package_name
+   :default: kubectl
+
+The package what should be installed.
+
+.. zuul:rolevar:: kubectl_configure_repository
+   :default: true
+
+Install apt-transport-https, because the kubectl repository can only be added via https.
+
+.. zuul:rolevar:: kubectl_debian_repository_arch
+   :default: amd64
+
+Repository architecture.
+
+.. zuul:rolevar:: kubectl_debian_repository_key
+   :default: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+
+Add the repository gpg-key.
+
+.. zuul:rolevar:: kubectl_debian_repository
+   :default: "deb [ arch={{ kubectl_debian_repository_arch }} ] https://apt.kubernetes.io/ kubernetes-xenial main"
+
+Define which repository you want to install.

--- a/roles/lynis/README.rst
+++ b/roles/lynis/README.rst
@@ -1,0 +1,28 @@
+This ansible role will install lynis.
+
+**Role Variables**
+
+.. zuul:rolevar:: lynis_package_name
+   :default: lynis
+
+The package that should be installed.
+
+.. zuul:rolevar:: lynis_configure_repository
+   :default: true
+
+Whether to add the lynis_debian_repository to the apt configuration.
+
+.. zuul:rolevar:: lynis_debian_repository_arch
+   :default: amd64
+
+Repository architecture.
+
+.. zuul:rolevar:: lynis_debian_repository_key
+   :default: https://packages.cisofy.com/keys/cisofy-software-public.key
+
+Add the repository gpg-key.
+
+.. zuul:rolevar:: lynis_debian_repository
+   :default: "deb [ arch={{ lynis_debian_repository_arch }} ] https://packages.cisofy.com/community/lynis/deb/ stable main"
+
+Define which repository you want to install.

--- a/roles/microcode/README.rst
+++ b/roles/microcode/README.rst
@@ -1,0 +1,19 @@
+Ansible role for the installation of microcode.
+
+**Role Variables**
+
+.. zuul:rolevar:: microcode_packages_default
+   :default: - amd64-microcode
+             - intel-microcode
+
+The packages that are needed for microcode
+
+.. zuul:rolevar:: microcode_packages_extra
+   :default: []
+
+Extra packages which you want to install.
+
+.. zuul:rolevar:: microcode_packages
+   :default: microcode_packages_default + microcode_packages_extra
+
+The whole packages that will be installed.

--- a/roles/operator/README.rst
+++ b/roles/operator/README.rst
@@ -1,0 +1,56 @@
+Ansible role to configure the operator user with all its dependencies.
+
+**Role Variables**
+
+.. zuul:rolevar:: operator_user
+   :default: dragon
+
+The operator user name.
+
+.. zuul:rolevar:: operator_user_id
+   :default: 45000
+
+ID for the operator user.
+
+.. zuul:rolevar:: operator_group
+   :default: dragon
+
+The group for the operator user.
+
+.. zuul:rolevar:: operator_group_id
+   :default: 45000
+
+ID for the group.
+
+.. zuul:rolevar:: operator_shell
+   :default: /bin/bash
+
+The default shell for the operator.
+
+.. zuul:rolevar:: operator_authorized_keys
+   :default: []
+
+A list of ssh authorized keys to add.
+
+.. zuul:rolevar:: operator_password
+
+Encrypted password string to set for the operator user (optional).
+
+.. warning:: 
+   Use "mkpasswd --method=sha-512" to generate an encrypted password.
+   Do not set this variable to a clear-text password.
+
+.. zuul:rolevar:: operator_sudo_nopasswd
+   :default: true
+
+Whether the operator user can invoke sudo without a password.
+
+.. zuul:rolevar:: operator_sudo_cmd_list
+   :default: ALL
+
+Commands that the user can use with sudo.
+
+.. zuul:rolevar:: operator_groups
+
+Additional groups for the operator user. The default list of groups is distribution
+specific.

--- a/roles/packages/README.rst
+++ b/roles/packages/README.rst
@@ -1,0 +1,49 @@
+This ansible role installs a number of required packages.
+
+**Role Variables**
+
+.. zuul:rolevar:: upgrade_packages
+   :default: true
+
+For updating the package cache.
+
+.. zuul:rolevar:: required_packages_default
+   :default: - ethtool
+             - jq
+             - rsyslog
+
+The required packages which are needed.
+
+.. zuul:rolevar:: required_packages_extra
+   :default: []
+
+Extra packages which you want to install.
+
+.. zuul:rolevar:: required_packages
+   :default: required_packages_default + required_packages_extra + required_packages_distribution
+
+The whole packages which should be installed.
+
+**Debian Variables**
+
+.. zuul:rolevar:: apt_cache_valid_time
+   :default: 3600
+
+Update the apt cache if it is older than the cache_valid_time.
+This option is set in seconds.
+
+
+.. zuul:rolevar:: required_packages_distribution
+   :default: - debsums
+             - selinux-utils
+             - ssh
+
+Required packages for Debian
+
+**RedHat Variables**
+
+.. zuul:rolevar:: required_packages_distribution
+   :default: - libselinux-utils
+             - openssh
+
+Required packages for RedHat

--- a/roles/podman/README.rst
+++ b/roles/podman/README.rst
@@ -1,0 +1,15 @@
+Ansible role to install podman.
+
+**Role Variables**
+
+.. zuul:rolevar:: podman_action
+   :default: deploy
+
+Name for which file should be iuncluded.
+
+Example: ``config.yml`` or ``deploy.yml``
+
+.. zuul:rolevar:: podman_package_name
+   :default: podman
+
+The required package for podman.

--- a/roles/proxy/README.rst
+++ b/roles/proxy/README.rst
@@ -1,0 +1,44 @@
+This ansible role will setup the proxies.
+
+**Role Variables**
+
+.. zuul:rolevar:: proxy_proxies
+   :default: {}
+
+The proxies which will be configured. Please declare which you want to configure.
+
+Example:
+
+.. code-block:: yaml
+   
+   proxy_proxies:
+   http: http://proxy.tld:8080
+   https: http://proxy.tld:8080
+   ftp: http://proxy.tld:8080
+
+
+.. zuul:rolevar:: proxy_no_proxy_default
+   :default: - 127.0.0.1
+             - localhost
+
+The addresses listed here are not configured via proxy.
+
+.. zuul:rolevar:: proxy_no_proxy_extra
+   :default: []
+
+Here you can list extra addresses which are not to be configured via proxy.
+
+.. zuul:rolevar:: proxy_no_proxy
+   :default: proxy_no_proxy_default + proxy_no_proxy_extra
+
+All addresses which should not configured via proxy
+
+.. zuul:rolevar:: proxy_package_manager
+   :default: true
+
+Also set proxy for the package manager.
+
+.. zuul:rolevar:: proxy_apt_conf_path
+   :default: /etc/apt/apt.conf.d/01proxy
+
+Debain specific path. This path is where to store the configuration file.

--- a/roles/repository/README.rst
+++ b/roles/repository/README.rst
@@ -1,0 +1,29 @@
+Ansible role to configure distribution-specific repositories.
+
+**Role Variables**
+
+.. zuul:rolevar:: repositories
+
+A dict of ``name:repository`` pairs, these will be added to the
+list of package sources. The format and default settings are
+distribution-specific.
+
+.. zuul:rolevar:: repository_cache_valid_time
+   :default: 120
+
+Update the apt cache if it is older than the cache_valid_time.
+This option is set in seconds.
+
+.. zuul:rolevar:: repository_key_files_directory
+   :default: /opt/configuration/environments/generic/files/repository/keys
+
+Keys stored in this directory are added to APT as trusted keys.
+
+.. zuul:rolevar:: repository_keys
+
+List of URLs from which to collect GPG keys that APT should trust.
+
+.. zuul:rolevar:: repository_key_ids
+
+Dict of ``ID:keyserver`` pairs, each key ID is fetched from its
+keyserver and added to APT as trusted key.

--- a/roles/resolvconf/README.rst
+++ b/roles/resolvconf/README.rst
@@ -1,0 +1,66 @@
+Ansible role for configuring nameserver and its components.
+
+**Role Variables**
+
+.. zuul:rolevar:: resolvconf_nameserver_default
+   :default: - 9.9.9.9
+             - 149.112.112.112
+
+The default IP addresses from the nameservers you want to choose for the configuration.
+
+.. zuul:rolevar:: resolvconf_nameserver_extra
+
+If you want to install extra nameservers declare it here.
+
+.. zuul:rolevar:: resolvconf_nameserver
+
+The whole list of nameservers you want to configure.
+
+.. zuul:rolevar:: resolvconf_fallback_nameserver
+
+Alternitive nameserver with IPv4 and IPv6 addresses in a list if no DNS server information is known.
+If this option is not set, a compiled-in list is used instead.
+
+.. zuul:rolevar:: resolvconf_search
+   :default: osism.test
+
+This is the local domain.
+
+.. zuul:rolevar:: resolvconf_minimum_number_of_nameservers
+   :default: 2
+
+The minimum number of nameserver of name servers that must be configured.
+
+.. zuul:rolevar:: resolvconf_cache
+   :default: true
+
+The cache for resolvconf. That means that requests are stored and takes the results from earlier requests.
+This is for a better performance because not every request is a new network request.
+
+.. zuul:rolevar:: resolvconf_cache_from_localhost
+   :default: false
+
+Sometimes in the case of development you will need to set the localhost cache on false.
+For this you can use this parameter.
+
+.. zuul:rolevar:: resolvconf_dns_over_tls
+   :default: false
+
+If true it will encrypted all connections, if false not. Please beware that you, if you want to use it, need a DNS server
+that supports DNS-over-TLS. You need a valid certificate too. Using DNS-over-TLS results in a little performance loss.
+
+.. zuul:rolevar:: resolvconf_dnssec
+   :default: allow-downgrade
+
+Does not enforce secured DNS requests. Fallback to normal (insecure) DNS is allowed. To enforce DNSSEC set this variable to true.
+This will only work on systems where DNSSEC is supported. Using it results in a little perfomance loss.
+
+.. zuul:rolevar:: resolvconf_read_etc_hosts
+   :default: true
+
+If set to true it allowes the systemd-resolved to read the /etc/hosts.
+
+.. zuul:rolevar:: resolvconf_file
+   :default: /etc/resolv.conf
+
+Path to the configuration file.

--- a/roles/services/README.rst
+++ b/roles/services/README.rst
@@ -1,0 +1,29 @@
+Ansible role for manage services.
+
+**Role Variables**
+
+.. zuul:rolevar:: services_warning_default
+   :default: nscd
+
+Have a look at services_warning.
+
+.. zuul:rolevar:: services_warning_extra
+
+Have a look at services_warning.
+
+.. zuul:rolevar:: services_warning
+
+Services which shouldn't be running. They will be displayed in a debug message.
+
+.. zuul:rolevar:: services_required_default
+   :default: cron
+
+Have a look at services_required.
+
+.. zuul:rolevar:: services_required_extra
+
+Have a look at services_required.
+
+.. zuul:rolevar:: services_required
+
+The services declared in a list which should be managed.

--- a/roles/sosreport/README.rst
+++ b/roles/sosreport/README.rst
@@ -1,0 +1,73 @@
+This ansible role installs and configures sosreport. Sosreport helps to
+collect informations from the configured plugins.
+
+**Role Variables**
+
+.. zuul:rolevar:: sosreport_unarchive
+   :default: false
+
+By default the sosreport will be unarchived on the destination machine
+after running. 
+
+.. zuul:rolevar:: sosreport_tmpdir
+   :default: /tmp/sosreport
+
+It is a temporary directory where the reports will be stored on the machine
+where the report is generated.
+
+.. zuul:rolevar:: sosreport_required_packages
+   :default: sosreport
+
+Required packages for sosreport.
+
+.. zuul:rolevar:: sosreport_name 
+
+The name will include by default the hostname and the date.
+It is the name under which the report will be stored.
+
+.. zuul:rolevar:: sosreport_archive_filename
+
+This will be the name from the archived sosreport.
+
+.. zuul:rolevar:: sosreport_archive_directory
+
+The directory where the archived sosreports will be stored in.
+
+.. zuul:rolevar:: sosreport_plugins
+   :default: - apt
+             - auditd
+             - block
+             - devices
+             - docker
+             - dpkg
+             - filesys
+             - hardware
+             - kernel
+             - kvm
+             - md
+             - memory
+             - networking
+             - pci
+             - process
+             - processor
+             - python
+             - services
+             - ssh
+             - system
+             - systemd
+             - ubuntu
+             - udev
+             - usb
+             - xfs
+
+From where sosreport should collect the informations which you needed.
+
+.. zuul:rolevar:: operator_user
+   :default: dragon
+
+The user with which sosreport should run and own the reqired directories.
+
+.. zuul:rolevar:: operator_group
+   :default: operator_user
+
+The group from the user with which sosreport should run and own the reqired directories.

--- a/roles/sshconfig/README.rst
+++ b/roles/sshconfig/README.rst
@@ -1,0 +1,47 @@
+Ansible Role for configuring the ssh-client. Makes it possible to connect
+via ssh to the hosts.
+
+**Role Variables**
+
+.. zuul:rolevar:: operator_user
+   :default: dragon
+
+The user who will own the configuration directory.
+
+.. zuul:rolevar:: operator_group
+   :default: operator_user
+
+The group which will own th econfiguration directory.
+
+.. zuul:rolevar:: sshconfig_destination
+   :default: /home/{{ operator_user }}/.ssh
+
+Directory where the configuration file will be stored in.
+
+.. zuul:rolevar:: sshconfig_groupname
+   :default: all
+
+The groups (hosts) which will be configured.
+
+.. zuul:rolevar:: sshconfig_order
+   :default: 20
+
+Priority for the ssh configuration file. The file will be stored in the
+config.d directory where oether files might exist. They are read in alphabetical 
+order and with this variable you can minipulate the order in which it will
+be evaluated.
+
+.. zuul:rolevar:: sshconfig_port
+   :default: 22
+
+The port on which the ssh-service will listen for connections.
+
+.. zuul:rolevar:: sshconfig_private_key_file
+   :default: /opt/ansible/secrets/id_rsa.operator
+
+The file in which the ssh key from the operator is stored.
+
+.. zuul:rolevar:: sshconfig_user
+   :default: operator_user
+
+User which should be used to establish the ssh connection.

--- a/roles/state/README.rst
+++ b/roles/state/README.rst
@@ -1,0 +1,23 @@
+This andible role transports facts into a state file.
+
+**Role Variables**
+
+.. zuul:rolevar:: state_name
+   :default: osism
+
+The name which the state file will have.
+
+.. zuul:rolevar:: state_section
+   :default: status
+
+This declares the section in the file where the facts have to be added.
+
+.. zuul:rolevar:: state_option
+   :default: deployed
+
+Given option that a fact must have befor adding to the file.
+
+.. zuul:rolevar:: state_value
+   :default: false
+
+The value that is given for checking a fact. # Fix me

--- a/roles/sysctl/README.rst
+++ b/roles/sysctl/README.rst
@@ -1,0 +1,14 @@
+This role configures sysctl (Kernelparameters). It can be used to tune
+the components from a system to a better perfoming way.Be aware that if
+you do it in the wrong way it can slow down the system too.
+
+**Role Variables**
+
+.. zuul:rolevar:: sysctl_defaults
+
+In this section are the parameters for elesticsearch, rabbitmq and the notes
+``all`` or ``compute`` are declared in a list.
+
+.. zuul:rolevar:: sysctl_extra
+
+Here you can declare extra variables that you want to configure. 

--- a/roles/sysdig/README.rst
+++ b/roles/sysdig/README.rst
@@ -1,0 +1,34 @@
+Ansible role for installation and configuration sysdig.
+Sysdig is a system visibility tool with native support for containers.
+
+**Role Variables**
+
+.. zuul:rolevar:: sysdig_package_name
+   :default: sysdig
+
+The required package which is needed.
+
+.. zuul:rolevar:: sysdig_kernel_module_name
+   :default: sysdig_probe
+
+The kernel module name for configuring and enabling sysdig.
+
+.. zuul:rolevar:: sysdig_configure_repository
+   :default: true
+
+For downloading packages via https, this package is needed first.
+
+.. zuul:rolevar:: sysdig_debian_repository_arch
+   :default: amd64
+
+This means the architecture from the system where you want to install sysdig.
+
+.. zuul:rolevar:: sysdig_debian_repository_key
+   :default: https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public
+
+The Url where the package will be downloaded from.
+
+.. zuul:rolevar:: sysdig_debian_repository
+   :default: deb [ arch={{ sysdig_debian_repository_arch }} ] https://download.sysdig.com/stable/deb stable-{{ sysdig_debian_repository_arch }}/
+
+Repository name from the sysdig-file for debian distributions.

--- a/roles/systohc/README.rst
+++ b/roles/systohc/README.rst
@@ -1,0 +1,12 @@
+This ansible role will synchronize the hardware clock.
+
+**Role Variables**
+
+.. zuul:rolevar:: systohc
+   :default: true
+
+When true the systemclock is synced to the hardwareclock.
+
+.. zuul:rolevar:: systohc_common
+
+# Fix me


### PR DESCRIPTION
- Docker_compose: Add documentation for the role
- Hostname: Add documentation for the role
- Facts: Add documentation for the role
- Hosts: Add documentation for the role
- Ipmitool: Add documentation for the role
- Kernel_modules: Add documentation for the role
- Known_hosts: Add documentation for the role
- Kompose: Add documentation for the role
- Kubectl: Add documentation for the role
- Lynis: Add documentation for the role
- Microcode: Add documentation for the role
- Network: Add documentation for the role
- Operator: Add documentation for the role
- Packages: Add documentation for the role
- Podman: Add documentation for the role
- Proxy: Add documentation for the role
- Repository: Add documentation for the role
