### PR TITLE
docker_compose: install pass package

### DIFF
--- a/roles/docker_compose/tasks/install.yml
+++ b/roles/docker_compose/tasks/install.yml
@@ -24,5 +24,6 @@
     name:
       - "{{ docker_compose_package_name }}"
       - "{{ docker_compose_plugin_package_name }}"
+      - pass
     state: present
     install_recommends: false


### PR DESCRIPTION
This will solve the following issue:

error getting credentials - err: exit status 1, out: `Cannot autolaunch
D-Bus without X11 $DISPLAY`

Closes #353

Signed-off-by: Christian Berendt <berendt@osism.tech>