### PR TITLE
Add tox-linters job

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,7 @@ exclude_paths:
   - .github/playbook-publish-collection.yml
 mock_modules:
   - scan_services
+skip_list:
+  - experimental  # all rules tagged as experimental
+  - parser-error  # AnsibleParserError.
+  - var-spacing  # Variables should have spaces before and after: {{ var_name }}.

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,3 +4,7 @@ extends: default
 rules:
   comments: enable
   line-length: disable
+
+ignore: |
+  .git
+  .tox

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,6 +3,8 @@
     check:
       jobs:
         - build-sphinx-docs
+        - tox-linters
     gate:
       jobs:
         - build-sphinx-docs
+        - tox-linters

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,11 @@ deps =
 commands =
   sphinx-build -E -W -d doc/build/doctrees -b html doc/source/ doc/build/html
 
+[testenv:linters]
+deps =
+    ansible-lint
+    ansible
+    yamllint
+commands =
+  yamllint -s .
+  ansible-lint


### PR DESCRIPTION
Run yamllint and ansible-lint as check job via tox-linters.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>