### PR TITLE
certificates: add CA certs to Python, eg apt_key uses python key store

### DIFF
--- a/roles/certificates/tasks/main.yml
+++ b/roles/certificates/tasks/main.yml
@@ -12,3 +12,6 @@
     mode: 0644
   loop: "{{ certificates_ca }}"
   notify: Update CA certificates
+
+- name: Include distribution specific Python tasks
+  ansible.builtin.include_tasks: "python-{{ ansible_os_family }}.yml"

--- a/roles/certificates/tasks/python-Debian.yml
+++ b/roles/certificates/tasks/python-Debian.yml
@@ -1,0 +1,9 @@
+---
+- name: Link CA certificates to Python
+  become: true
+  ansible.builtin.file:
+    src: /etc/ssl/certs/ca-certificates.crt
+    dest: /usr/lib/ssl/cert.pem
+    owner: root
+    group: root
+    state: link


### PR DESCRIPTION
Signed-off-by: Bernd Mueller <mueller@b1-systems.de>