### PR TITLE
Drop sphinxcontrib.openapi from doc requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,11 +3,6 @@ sphinx>=1.8
 sphinxcontrib-blockdiag>=1.1.0
 sphinxcontrib-programoutput
 sphinx-autodoc-typehints
-sphinxcontrib-openapi>=0.4.0
 sphinx_rtd_theme
 reno>=2.8.0 # Apache-2.0
 zuul-sphinx
-# mistune is a transitive requirement of sphinxcontrib-openapi
-# remove this requirement once this issue is fixed:
-# https://github.com/sphinx-contrib/openapi/issues/121
-mistune<2.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,6 @@ extensions = [
     'sphinx.ext.graphviz',
     'sphinxcontrib.blockdiag',
     'sphinxcontrib.programoutput',
-    'sphinxcontrib.openapi',
     'zuul_sphinx',
     'reno.sphinxext',
     'sphinx_rtd_theme',


### PR DESCRIPTION
We don't use the extension anywhere and it has a long standing bug that
hasn't been resolved. [0]

[0] https://github.com/sphinx-contrib/openapi/issues/121
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>