### PR TITLE
sysctl: use generic group instead of all group

### DIFF
--- a/roles/sysctl/defaults/main.yml
+++ b/roles/sysctl/defaults/main.yml
@@ -25,7 +25,7 @@ sysctl_defaults:
       value: 0
     - name: net.ipv4.tcp_max_syn_backlog
       value: 8192
-  all:
+  generic:
     - name: vm.swappiness
       value: 1
   compute:


### PR DESCRIPTION
We do not use the all group in OSISM. The correct group is generic.

Closes #375

Signed-off-by: Christian Berendt <berendt@osism.tech>