### PR TITLE
timezone: use Etc/UTC as new default

### DIFF
--- a/roles/timezone/README.rst
+++ b/roles/timezone/README.rst
@@ -5,9 +5,9 @@ Ansible role for timezone configuration.
 .. zuul:rolevar:: timezone_hwclock
    :default: UTC
 
-The timezone which the system has to use.
+Whether the hardware clock is in UTC or in local timezone. Possible values are local and UTC.
 
 .. zuul:rolevar:: timezone_name
    :default: UTC
 
-Name of the timezone which should be used.
+Name of the timezone for the system clock.

--- a/roles/timezone/defaults/main.yml
+++ b/roles/timezone/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 timezone_hwclock: UTC
-timezone_name: UTC
+timezone_name: Etc/UTC


### PR DESCRIPTION
Required by Ubuntu 22.04.

Also improve the parameter documentation.

Signed-off-by: Christian Berendt <berendt@osism.tech>