### PR TITLE
ansible-lint: only warn about experimental rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,3 +12,5 @@ skip_list:
   - schema
   - fqcn-builtins
   - name[template]
+warn_list:
+  - experimental  # all rules tagged as experimental


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>