### PR TITLE
Add docker_login role

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The following Ansible roles are included in this collection.
 | configfs             | ![Test role configfs](https://github.com/osism/ansible-collection-commons/workflows/Test%20role%20configfs/badge.svg)             |
 | configuration        | ![Test role configuration](https://github.com/osism/ansible-collection-commons/workflows/Test%20role%20configuration/badge.svg)   |
 | docker_compose       | ![Test role docker_compose](https://github.com/osism/ansible-collection-commons/workflows/Test%20role%20docker_compose/badge.svg) |
+| docker_login         |                                                                                                                                   |
 | facts                | ![Test role facts](https://github.com/osism/ansible-collection-commons/workflows/Test%20role%20facts/badge.svg)                   |
 | firewall             | ![Test role firewall](https://github.com/osism/ansible-collection-commons/workflows/Test%20role%20firewall/badge.svg)             |
 | hostname             | ![Test role hostname](https://github.com/osism/ansible-collection-commons/workflows/Test%20role%20hostname/badge.svg)             |

--- a/roles/docker_login/README.rst
+++ b/roles/docker_login/README.rst
@@ -1,0 +1,18 @@
+Ansible role to login to a self-hosted registry.
+
+**Role Variables**
+
+.. zuul:rolevar:: docker_login_registry
+   :default: index.docker.io
+
+The self-hosted registry to login to.
+
+.. zuul:rolevar:: docker_login_username
+   :default: ""
+
+Username.
+
+.. zuul:rolevar:: docker_login_password
+   :default: ""
+
+Password.

--- a/roles/docker_login/defaults/main.yml
+++ b/roles/docker_login/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+docker_login_registry: index.docker.io
+docker_login_username:
+docker_login_password:

--- a/roles/docker_login/meta/main.yml
+++ b/roles/docker_login/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Christian Berendt
+  description: Role osism.commons.docker_login
+  company: OSISM GmbH
+  license: Apache License 2.0
+  min_ansible_version: 2.10.0
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+  galaxy_tags:
+    - osism
+    - system
+dependencies: []

--- a/roles/docker_login/tasks/main.yml
+++ b/roles/docker_login/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Wait for apt lock
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
+  loop:
+    - lock
+    - lock-frontend
+  changed_when: false
+
+- name: Install packages required by docker login
+  become: true
+  ansible.builtin.apt:
+    name: ["gnupg2", "pass"]
+    state: present
+
+- name: Login to registry and force re-authorization
+  community.docker.docker_login:
+    registry: "{{ docker_login_registry }}"
+    username: "{{ docker_login_username }}"
+    password: "{{ docker_login_password }}"
+    reauthorize: true


### PR DESCRIPTION
The docker_login role can be used to login to a registry independently of the osism.services.docker role.

Signed-off-by: Christian Berendt <berendt@osism.tech>