### PR TITLE
repository: add enable_phased_updates parameter

### DIFF
--- a/roles/repository/README.rst
+++ b/roles/repository/README.rst
@@ -17,22 +17,34 @@ release, ``-backports``, ``-security`` and ``-updates`` pockets.
 .. zuul:rolevar:: repository_cache_valid_time
    :default: 120
 
-Only for Debian/Ubuntu: Update the apt cache if it is older than
-the ``cache_valid_time``.  This option is set in seconds.
+Only for Debian/Ubuntu:
+
+Update the apt cache if it is older than the ``cache_valid_time``.
+This option is set in seconds.
 
 .. zuul:rolevar:: repository_key_files_directory
    :default: ""
 
 Only for Debian/Ubuntu:
+
 Keys stored in this directory are added to APT as trusted keys.
 
 .. zuul:rolevar:: repository_keys
 
 Only for Debian/Ubuntu:
+
 List of URLs from which to collect GPG keys that APT should trust.
 
 .. zuul:rolevar:: repository_key_ids
 
 Only for Debian/Ubuntu:
+
 Dict of ``ID:keyserver`` pairs, each key ID is fetched from its
 keyserver and added to APT as trusted key.
+
+.. zuul:rolevar:: enable_phased_updates
+   :default: false
+
+Only for Debian/Ubuntu:
+
+Enable phased updates.

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -5,3 +5,5 @@ repository_cache_valid_time: 120
 repository_key_files_directory: ""
 repository_keys: []
 repository_key_ids: {}
+
+enable_phased_updates: false

--- a/roles/repository/tasks/repository-Debian.yml
+++ b/roles/repository/tasks/repository-Debian.yml
@@ -1,4 +1,11 @@
 ---
+- name: Copy 99osism apt configuration
+  become: true
+  ansible.builtin.template:
+    src: 99osism.j2
+    dest: /etc/apt/apt.conf.d/99osism
+    mode: 0644
+
 - name: Add repository keys via URLs
   become: true
   ansible.builtin.apt_key:

--- a/roles/repository/templates/99osism.j2
+++ b/roles/repository/templates/99osism.j2
@@ -1,0 +1,3 @@
+{% if not enable_phased_updates|bool %}
+Update-Manager::Never-Include-Phased-Updates;
+{% endif %}


### PR DESCRIPTION
With the enable_phased_updates parameter it is possible to control the use of phased updates on Debian/Ubuntu. Phased updates are disabled by default.

Closes osism/issues#210

Signed-off-by: Christian Berendt <berendt@osism.tech>