### PR TITLE
remove: rpcbind

### DIFF
--- a/roles/cleanup/vars/Debian.yml
+++ b/roles/cleanup/vars/Debian.yml
@@ -4,5 +4,6 @@ cleanup_packages_distribution:
   - libvirt-bin
   - lxd
   - open-iscsi
+  - rpcbind
 
 cleanup_cloudinit_package_name: cloud-init


### PR DESCRIPTION
rpcbind is not needed by default setup
if rpcbind is required for example  by nfs
it will installed by dependency of nfs-common

Closes osism/testbed#1489
Signed-off-by: Mathias Fechner <fechner@osism.tech>