### PR TITLE
repository: add repository_apt_acquire_forceipv4

### DIFF
--- a/roles/repository/README.rst
+++ b/roles/repository/README.rst
@@ -48,3 +48,10 @@ keyserver and added to APT as trusted key.
 Only for Debian/Ubuntu:
 
 Enable phased updates.
+
+.. zuul:rolevar:: repository_apt_acquire_forceipv4
+   :default: false
+
+Only for Debian/Ubuntu:
+
+Forcing IPv4 transport with apt-get.

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -7,3 +7,5 @@ repository_keys: []
 repository_key_ids: {}
 
 enable_phased_updates: false
+
+repository_apt_acquire_forceipv4: false

--- a/roles/repository/templates/99osism.j2
+++ b/roles/repository/templates/99osism.j2
@@ -1,3 +1,6 @@
 {% if not enable_phased_updates|bool %}
 Update-Manager::Never-Include-Phased-Updates;
 {% endif %}
+{% if repository_apt_acquire_forceipv4|bool %}
+Acquire::ForceIPv4 "true";
+{% endif %}


### PR DESCRIPTION
Only for Debian/Ubuntu:

Forcing IPv4 transport with apt-get.