### PR TITLE
Do not use apt-key on Ubuntu 22.04

### DIFF
--- a/roles/kubectl/README.rst
+++ b/roles/kubectl/README.rst
@@ -5,12 +5,12 @@ This ansible role will install kubectl
 .. zuul:rolevar:: kubectl_package_name
    :default: kubectl
 
-The package what should be installed.
+Name of the kubctl package.
 
 .. zuul:rolevar:: kubectl_configure_repository
    :default: true
 
-Install apt-transport-https, because the kubectl repository can only be added via https.
+Configure repository.
 
 .. zuul:rolevar:: kubectl_debian_repository_arch
    :default: amd64
@@ -18,11 +18,11 @@ Install apt-transport-https, because the kubectl repository can only be added vi
 Repository architecture.
 
 .. zuul:rolevar:: kubectl_debian_repository_key
-   :default: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+   :default: https://raw.githubusercontent.com/kubernetes/k8s.io/main/apt/doc/apt-key.gpg
 
-Add the repository gpg-key.
+Repository gpg key.
 
 .. zuul:rolevar:: kubectl_debian_repository
-   :default: "deb [ arch={{ kubectl_debian_repository_arch }} ] https://apt.kubernetes.io/ kubernetes-xenial main"
+   :default: "deb [ arch={{ kubectl_debian_repository_arch }} signed-by=/usr/share/keyrings/kubectl.gpg ] https://apt.kubernetes.io/ kubernetes-xenial main"
 
-Define which repository you want to install.
+Repository URL.

--- a/roles/kubectl/defaults/main.yml
+++ b/roles/kubectl/defaults/main.yml
@@ -10,5 +10,5 @@ kubectl_package_name: kubectl
 kubectl_configure_repository: true
 
 kubectl_debian_repository_arch: amd64
-kubectl_debian_repository_key: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-kubectl_debian_repository: "deb [ arch={{ kubectl_debian_repository_arch }} ] https://apt.kubernetes.io/ kubernetes-xenial main"
+kubectl_debian_repository_key: https://raw.githubusercontent.com/kubernetes/k8s.io/main/apt/doc/apt-key.gpg
+kubectl_debian_repository: "deb [ arch={{ kubectl_debian_repository_arch }} signed-by=/usr/share/keyrings/kubectl.gpg ] https://apt.kubernetes.io/ kubernetes-xenial main"

--- a/roles/kubectl/tasks/install-Debian.yml
+++ b/roles/kubectl/tasks/install-Debian.yml
@@ -17,8 +17,12 @@
 
 - name: Add repository gpg key
   become: true
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: "{{ kubectl_debian_repository_key }}"
+    dest: /usr/share/keyrings/kubectl.gpg
+    mode: 0644
+    owner: root
+    group: root
   when: kubectl_configure_repository|bool
 
 - name: Add repository

--- a/roles/lynis/tasks/install-Debian.yml
+++ b/roles/lynis/tasks/install-Debian.yml
@@ -15,11 +15,25 @@
   when: lynis_configure_repository|bool
   changed_when: false
 
-- name: Add repository gpg key
+- name: Add repository gpg key with apt-key
   become: true
   ansible.builtin.apt_key:
     url: "{{ lynis_debian_repository_key }}"
-  when: lynis_configure_repository|bool
+  when:
+    - lynis_configure_repository|bool
+    - ansible_distribution_version is version('22.04', '<')
+
+- name: Add repository gpg key
+  become: true
+  ansible.builtin.get_url:
+    url: "{{ lynis_debian_repository_key }}"
+    dest: /etc/apt/trusted.gpg.d/lynis.asc
+    mode: 0644
+    owner: root
+    group: root
+  when:
+    - lynis_configure_repository|bool
+    - ansible_distribution_version is version('22.04', '>=')
 
 - name: Add repository
   become: true

--- a/roles/repository/tasks/repository-Debian.yml
+++ b/roles/repository/tasks/repository-Debian.yml
@@ -6,20 +6,44 @@
     dest: /etc/apt/apt.conf.d/99osism
     mode: 0644
 
-- name: Add repository keys via URLs
+- name: Add repository keys via URLs with apt-key
   become: true
   ansible.builtin.apt_key:
     url: "{{ item }}"
     state: present
   loop: "{{ repository_keys }}"
+  when: ansible_distribution_version is version('22.04', '<')
 
-- name: Add repository keys via keyservers
+- name: Add repository keys via URLs
+  become: true
+  ansible.builtin.get_url:
+    url: "{{ item }}"
+    dest: "/etc/apt/trusted.gpg.d/repository-{{ ansible_loop.index }}.asc"
+    mode: 0644
+    owner: root
+    group: root
+  loop: "{{ repository_keys }}"
+  when: ansible_distribution_version is version('22.04', '>=')
+
+- name: Add repository keys via keyservers with apt-key
   become: true
   ansible.builtin.apt_key:
     id: "{{ item.key }}"
     keyserver: "{{ item.value }}"
     state: present
   loop: "{{ repository_key_ids|dict2items }}"
+  when: ansible_distribution_version is version('22.04', '<')
+
+- name: Add repository keys via keyservers
+  ansible.builtin.fail:
+    msg: |
+      Adding repository keys via a keyserver is currently not supported
+      on Ubuntu 22.04. Please store the corresponding keys in the configuration
+      repository as files and set the repository_key_files_directory parameter
+      (e.g. /opt/configuration/files/repository_keys).
+  when:
+    - ansible_distribution_version is version('22.04', '>=')
+    - repository_key_ids
 
 # NOTE: We ignore errors that can occur during the seeding of the
 #       environment in constellations where the repository keys are
@@ -31,13 +55,28 @@
   delegate_to: "{{ groups['manager'][0] }}"
   ignore_errors: true
 
-- name: Add repository keys via files
+- name: Add repository keys via files with apt-key
   become: true
   ansible.builtin.apt_key:
     data: "{{ lookup('file', item) }}"
     state: present
   with_fileglob: "{{ repository_key_files_directory }}/*"
-  when: result is defined and result.stat.isdir is defined and result.stat.isdir
+  when:
+    - result is defined and result.stat.isdir is defined and result.stat.isdir
+    - ansible_distribution_version is version('22.04', '<')
+
+- name: Add repository keys via files
+  become: true
+  ansible.builtin.copy:
+    content: "{{ lookup('file', item) }}"
+    dest: "/etc/apt/trusted.gpg.d/{{ ansible_loop.index }}.asc"
+    mode: 0644
+    owner: root
+    group: root
+  with_fileglob: "{{ repository_key_files_directory }}/*"
+  when:
+    - result is defined and result.stat.isdir is defined and result.stat.isdir
+    - ansible_distribution_version is version('22.04', '>=')
 
 # NOTE: Not using apt_repository here because it requires python-apt.
 

--- a/roles/sysdig/tasks/install-Debian.yml
+++ b/roles/sysdig/tasks/install-Debian.yml
@@ -14,11 +14,25 @@
     lock_timeout: "{{ apt_lock_timeout|default(300) }}"
   when: sysdig_configure_repository|bool
 
-- name: Add repository gpg key
+- name: Add repository gpg key with apt-key
   become: true
   ansible.builtin.apt_key:
     url: "{{ sysdig_debian_repository_key }}"
-  when: sysdig_configure_repository|bool
+  when:
+    - sysdig_configure_repository|bool
+    - ansible_distribution_version is version('22.04', '<')
+
+- name: Add repository gpg key
+  become: true
+  ansible.builtin.get_url:
+    url: "{{ sysdig_debian_repository_key }}"
+    dest: /etc/apt/trusted.gpg.d/sysdig.asc
+    mode: 0644
+    owner: root
+    group: root
+  when:
+    - sysdig_configure_repository|bool
+    - ansible_distribution_version is version('22.04', '>=')
 
 - name: Add repository
   become: true

--- a/roles/trivy/tasks/install-Debian.yml
+++ b/roles/trivy/tasks/install-Debian.yml
@@ -15,11 +15,25 @@
   when: trivy_configure_repository|bool
   changed_when: false
 
-- name: Add repository gpg key
+- name: Add repository gpg key with apt-key
   become: true
   ansible.builtin.apt_key:
     url: "{{ trivy_debian_repository_key }}"
-  when: trivy_configure_repository|bool
+  when:
+    - trivy_configure_repository|bool
+    - ansible_distribution_version is version('22.04', '<')
+
+- name: Add repository gpg key
+  become: true
+  ansible.builtin.get_url:
+    url: "{{ trivy_debian_repository_key }}"
+    dest: /etc/apt/trusted.gpg.d/trivy.asc
+    mode: 0644
+    owner: root
+    group: root
+  when:
+    - trivy_configure_repository|bool
+    - ansible_distribution_version is version('22.04', '>=')
 
 - name: Add repository
   become: true


### PR DESCRIPTION
Part of osism/issues#381