### PR TITLE
Change default docker login registry to osism mirror

### DIFF
--- a/roles/docker_login/defaults/main.yml
+++ b/roles/docker_login/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-docker_login_registry: index.docker.io
+docker_login_registry: registry.airgap.services.osism.tech
 docker_login_username:
 docker_login_password:


### PR DESCRIPTION
extends #451

Signed-off-by: Tim Beermann <beermann@osism.tech>
