### PR TITLE
Role motd: Remove all "Wait for apt lock“ tasks

### DIFF
--- a/roles/motd/tasks/configure-Debian.yml
+++ b/roles/motd/tasks/configure-Debian.yml
@@ -1,12 +1,4 @@
 ---
-- name: Wait for apt lock
-  become: true
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Remove update-motd package
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
Partly osism/issues#464

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
