### PR TITLE
Role network: Remove all "Wait for apt lock“ tasks

### DIFF
--- a/roles/network/tasks/type-interfaces.yml
+++ b/roles/network/tasks/type-interfaces.yml
@@ -32,13 +32,6 @@
   tags:
     - always
 
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Install required packages
   become: true
   ansible.builtin.apt:

--- a/roles/network/tasks/type-netplan.yml
+++ b/roles/network/tasks/type-netplan.yml
@@ -1,11 +1,4 @@
 ---
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Install required packages
   become: true
   ansible.builtin.apt:
@@ -84,13 +77,6 @@
     owner: root
     group: root
   loop: "{{ network_dispatcher_scripts }}"
-
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
 
 - name: "Install {{ network_dispatcher_package_name }} package"
   become: true


### PR DESCRIPTION
Partly osism/issues#464

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
