### PR TITLE
Role packages: Remove all "Wait for apt lock“ tasks

### DIFF
--- a/roles/packages/tasks/package-Debian.yml
+++ b/roles/packages/tasks/package-Debian.yml
@@ -1,12 +1,4 @@
 ---
-- name: Wait for apt lock
-  become: true
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Update package cache
   become: true
   ansible.builtin.apt:
@@ -14,28 +6,12 @@
     cache_valid_time: "{{ apt_cache_valid_time }}"
     lock_timeout: "{{ apt_lock_timeout|default(300) }}"
 
-- name: Wait for apt lock
-  become: true
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Upgrade packages
   become: true
   ansible.builtin.apt:
     upgrade: dist
     lock_timeout: "{{ apt_lock_timeout|default(300) }}"
   when: upgrade_packages|bool
-
-- name: Wait for apt lock
-  become: true
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
 
 - name: Install required packages
   become: true


### PR DESCRIPTION
Partly osism/issues#464

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
