### PR TITLE
Role timezone: Remove all "Wait for apt lock“ tasks

### DIFF
--- a/roles/timezone/tasks/main.yml
+++ b/roles/timezone/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-- name: Wait for apt lock
-  ansible.builtin.shell: "while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do sleep 5; done;"
-  loop:
-    - lock
-    - lock-frontend
-  changed_when: false
-
 - name: Install tzdata package
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
Partly osism/issues#464

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
