### PR TITLE
Ansible-lint: Rework noqas

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,8 +14,8 @@ rulesdir:
   - ./.ansible-lint-rules/
 skip_list:
   - galaxy[no-changelog]
-  - schema
   - var-naming[no-role-prefix]
+  - package-latest
 # DO NOT DELETE THE WARNLIST! It is required for our custom rules!
 # If this isn't there our custom rules will only through a warning and wont generate a failure!:
 warn_list:

--- a/roles/cleanup/meta/main.yml
+++ b/roles/cleanup/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
         - jammy
     - name: EL
       versions:
-        - 8
+        - "8"
   galaxy_tags:
     - osism
     - system

--- a/roles/clevis/meta/main.yml
+++ b/roles/clevis/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
         - jammy
     - name: EL
       versions:
-        - 8
+        - "8"
   galaxy_tags:
     - osism
     - system

--- a/roles/configuration/tasks/git.yml
+++ b/roles/configuration/tasks/git.yml
@@ -1,7 +1,7 @@
 ---
 - name: Git - set configuration_git_repository_url fact (with username or personal access token)
   ansible.builtin.set_fact:
-    configuration_git_repository_url: "{{ configuration_git_protocol }}://{{ configuration_git_username }}@{{ configuration_git_host }}:{{ configuration_git_port }}/{{ configuration_git_repository }}"  # noqa 204
+    configuration_git_repository_url: "{{ configuration_git_protocol }}://{{ configuration_git_username }}@{{ configuration_git_host }}:{{ configuration_git_port }}/{{ configuration_git_repository }}"
   when: configuration_git_username is defined and configuration_git_username | length
   # NOTE: No logs are output to avoid leaking a PAT if it is used as a username.
   no_log: true
@@ -9,7 +9,7 @@
 
 - name: Git - set configuration_git_repository_url fact (without username)
   ansible.builtin.set_fact:
-    configuration_git_repository_url: "{{ configuration_git_protocol }}://{{ configuration_git_host }}:{{ configuration_git_port }}/{{ configuration_git_repository }}"  # noqa 204
+    configuration_git_repository_url: "{{ configuration_git_protocol }}://{{ configuration_git_host }}:{{ configuration_git_port }}/{{ configuration_git_repository }}"
   when: configuration_git_username is not defined or not configuration_git_username | length
   tags: update-configuration
 

--- a/roles/motd/meta/main.yml
+++ b/roles/motd/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
         - jammy
     - name: EL
       versions:
-        - 8
+        - "8"
   galaxy_tags:
     - osism
     - system

--- a/roles/packages/meta/main.yml
+++ b/roles/packages/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
         - jammy
     - name: EL
       versions:
-        - 8
+        - "8"
   galaxy_tags:
     - osism
     - system

--- a/roles/packages/tasks/package-RedHat.yml
+++ b/roles/packages/tasks/package-RedHat.yml
@@ -1,14 +1,14 @@
 ---
 - name: Update package cache
   become: true
-  ansible.builtin.dnf:  # noqa package-latest
+  ansible.builtin.dnf:
     name: '*'
     update_cache: true
     state: latest
 
 - name: Upgrade packages
   become: true
-  ansible.builtin.dnf:  # noqa package-latest
+  ansible.builtin.dnf:
     name: '*'
     state: latest
   when: upgrade_packages | bool

--- a/roles/repository/meta/main.yml
+++ b/roles/repository/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
         - jammy
     - name: EL
       versions:
-        - 8
+        - "8"
   galaxy_tags:
     - osism
     - system

--- a/roles/resolvconf/meta/main.yml
+++ b/roles/resolvconf/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
         - jammy
     - name: EL
       versions:
-        - 8
+        - "8"
   galaxy_tags:
     - osism
     - system

--- a/roles/resolvconf/tasks/configure-resolv.yml
+++ b/roles/resolvconf/tasks/configure-resolv.yml
@@ -35,13 +35,13 @@
       dest: /etc/systemd/resolved.conf
   register: resolved_conf
 
-- name: Restart systemd-resolved service
+- name: Restart systemd-resolved service  # noqa no-handler
   become: true
   ansible.builtin.systemd:
     name: systemd-resolved
     daemon_reload: true
     state: restarted
-  when: resolved_conf.changed  # noqa no-handler
+  when: resolved_conf.changed
 
 - name: "Link /run/systemd/resolve/stub-resolv.conf to {{ resolvconf_file }}"
   become: true

--- a/roles/timezone/tasks/main.yml
+++ b/roles/timezone/tasks/main.yml
@@ -9,7 +9,7 @@
 # NOTE: We use a variable for the value of hwclock at this point. However,
 # ansible-lint expects UTC or Local and does not resolve the default value
 # of the variable. Therefore, the rule args[module] is ignored at this point.
-- name: "Set timezone to {{ timezone_name }}"  # # noqa: args[module]
+- name: "Set timezone to {{ timezone_name }}"  # noqa:args[module]
   become: true
   community.general.timezone:
     hwclock: "{{ timezone_hwclock }}"


### PR DESCRIPTION
Rework the noqas from numbers to names.
Add some noqas for some issues found by ansible-lint localy
Partly osism/issues#496

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
