### PR TITLE
Docs: Pin Sphinx version to fix broken build pipeline

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 ansible
-sphinx>=1.8
+sphinx==6.2.1
 sphinxcontrib-blockdiag>=1.1.0
 sphinxcontrib-programoutput
 sphinx-autodoc-typehints


### PR DESCRIPTION
After an update of sphinx the sphinx_rtd_theme seems not working.
This patch will pin the version of sphinx to an older one.

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
