### PR TITLE
repository: run "Check if the keys directory exists"  only once

### DIFF
--- a/roles/repository/tasks/repository-Debian.yml
+++ b/roles/repository/tasks/repository-Debian.yml
@@ -54,6 +54,7 @@
   register: result
   delegate_to: "{{ groups['manager'][0] }}"
   ignore_errors: true
+  run_once: true
 
 - name: Add repository keys via files with apt-key
   become: true


### PR DESCRIPTION
Add 'run_once' option to the task to ensure it runs only once on the first host in the 'manager' group