### PR TITLE
resolvconf: add task to start and enable systemd-resolved service

### DIFF
--- a/roles/resolvconf/tasks/configure-resolv.yml
+++ b/roles/resolvconf/tasks/configure-resolv.yml
@@ -1,5 +1,5 @@
 ---
-- name: Stopp/disable resolvconf service
+- name: Stop/disable resolvconf service
   become: true
   ansible.builtin.service:
     name: resolvconf
@@ -34,6 +34,13 @@
     - src: resolved.conf.j2
       dest: /etc/systemd/resolved.conf
   register: resolved_conf
+
+- name: Start/enable systemd-resolved service
+  become: true
+  ansible.builtin.systemd:
+    name: systemd-resolved
+    enabled: true
+    state: started
 
 - name: Restart systemd-resolved service  # noqa no-handler
   become: true


### PR DESCRIPTION
Make sure that the service is also activated and started so that this is boot safe. there are debian(-based) distributions where the resolvconf is not already active by default.