### PR TITLE
network: add missing ubuntu-22.04.yml file

### DIFF
--- a/roles/network/vars/interfaces/ubuntu-22.04.yml
+++ b/roles/network/vars/interfaces/ubuntu-22.04.yml
@@ -1,0 +1,6 @@
+---
+network_service: networking.service
+
+# Don't use the service restart for individual interfaces as
+# `systemctl restart networking.service` does not take INTERFACE args
+network_restart_method: interface


### PR DESCRIPTION
This way it is possible to also use interfaces type with Ubuntu 22.04.