### PR TITLE
network: warning when interfaces used on Ubuntu >= 22.04

### DIFF
--- a/roles/network/tasks/type-interfaces.yml
+++ b/roles/network/tasks/type-interfaces.yml
@@ -1,4 +1,9 @@
 ---
+- name: Warning when used on Ubuntu >= 22.04
+  debug:
+    msg: "For Ubuntu >= 22.04 Netplan should be used instead of Interface"
+  when: "ansible_distribution is version('22.04, '>=')"
+
 - name: Get existing netplan configuration files
   ansible.builtin.find:
     paths: "{{ network_netplan_path }}"


### PR DESCRIPTION
Closes osism/issues#586