### PR TITLE
 Make it possible to use FQDN instead of shortname when bootstrapping #617 

### DIFF
--- a/roles/hostname/defaults/main.yml
+++ b/roles/hostname/defaults/main.yml
@@ -1,1 +1,2 @@
 ---
+hostname_use_fqdn: false

--- a/roles/hostname/tasks/main.yml
+++ b/roles/hostname/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set Servername
   ansible.builtin.set_fact:
-    servername: "{{ inventory_hostname if hostname_use_fqdni | bool else inventory_hostname_short }}"
+    servername: "{{ inventory_hostname if hostname_use_fqdn | bool else inventory_hostname_short }}"
 
 - name: Set hostname
   become: true

--- a/roles/hostname/tasks/main.yml
+++ b/roles/hostname/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: set hostname
-  set_fact:
-    servername: "{{ inventory_hostname if hostname_use_fqdn|bool else inventory_hostname_short }}"
+- name: Set Servername
+  ansible.builtin.set_fact:
+    servername: "{{ inventory_hostname if hostname_use_fqdni | bool else inventory_hostname_short }}"
 
 - name: Set hostname
   become: true

--- a/roles/hostname/tasks/main.yml
+++ b/roles/hostname/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
+- name: set hostname
+  set_fact:
+    servername: "{{ inventory_hostname if hostname_use_fqdn|bool else inventory_hostname_short }}"
+
 - name: Set hostname
   become: true
   ansible.builtin.hostname:
-    name: "{{ inventory_hostname_short }}"
+    name: "{{ servername }}"
 
 - name: Copy /etc/hostname
   become: true

--- a/roles/hostname/templates/config.j2
+++ b/roles/hostname/templates/config.j2
@@ -1,1 +1,1 @@
-{{ inventory_hostname_short }}
+{{ servername }}


### PR DESCRIPTION
Added a Flag to use fqdn if wanted as described in issue #617 