### PR TITLE
hostname: add flag to use fqdn

### DIFF
--- a/roles/hostname/README.rst
+++ b/roles/hostname/README.rst
@@ -1,2 +1,10 @@
-Ansible role for setting up the hostname. It uses the short hostname 
-provided from the ansible inventory.
+Ansible role for setting the hostname. It uses either the short
+or the full hostname from the ansible inventory.
+
+**Role Variables**
+
+.. zuul:rolevar:: hostname_use_fqdn
+   :default: false
+
+Whether to use the full name (`inventory_hostname`) instead of the
+short name (`inventory_hostname_short`) as hostname.

--- a/roles/hostname/defaults/main.yml
+++ b/roles/hostname/defaults/main.yml
@@ -1,1 +1,2 @@
 ---
+hostname_use_fqdn: false

--- a/roles/hostname/tasks/main.yml
+++ b/roles/hostname/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
+- name: Set hostname_name fact
+  ansible.builtin.set_fact:
+    hostname_name: "{{ inventory_hostname if hostname_use_fqdn | bool else inventory_hostname_short }}"
+
 - name: Set hostname
   become: true
   ansible.builtin.hostname:
-    name: "{{ inventory_hostname_short }}"
+    name: "{{ hostname_name }}"
 
 - name: Copy /etc/hostname
   become: true

--- a/roles/hostname/templates/config.j2
+++ b/roles/hostname/templates/config.j2
@@ -1,1 +1,1 @@
-{{ inventory_hostname_short }}
+{{ hostname_name }}


### PR DESCRIPTION
This allows to use the full FQDN as hostname instead of just the short version.

Closes: osism/issues#617