### PR TITLE
operator: Use C.UTF-8 as locale

### DIFF
--- a/roles/operator/tasks/main.yml
+++ b/roles/operator/tasks/main.yml
@@ -44,9 +44,9 @@
     create: true
     mode: 0640
   loop:
-    - "export LANGUAGE=en_US.UTF-8"
-    - "export LANG=en_US.UTF-8"
-    - "export LC_ALL=en_US.UTF-8"
+    - "export LANGUAGE=C.UTF-8"
+    - "export LANG=C.UTF-8"
+    - "export LC_ALL=C.UTF-8"
 
 - name: Create .ssh directory
   become: true


### PR DESCRIPTION
Using LANG=en_US.UTF-8 has some unwanted side effects, in particular using a 12h time format, which can be confusing. Use C.UTF-8 as proper international locale instead.