### PR TITLE
operator: add operator_authorized_github_accounts parameter

### DIFF
--- a/roles/operator/README.rst
+++ b/roles/operator/README.rst
@@ -30,7 +30,12 @@ The default shell for the operator.
 .. zuul:rolevar:: operator_authorized_keys
    :default: []
 
-A list of ssh authorized keys to add.
+List of SSH public keys to add to the authorized keys for the operator account.
+
+.. zuul:rolevar:: operator_authorized_github_accounts
+   :default: []
+
+List of Github accounts from which the SSH public keys are added to the authorized keys.
 
 .. zuul:rolevar:: operator_password
 

--- a/roles/operator/defaults/main.yml
+++ b/roles/operator/defaults/main.yml
@@ -8,6 +8,7 @@ operator_group_id: 45000
 operator_shell: /bin/bash
 
 operator_authorized_keys: []
+operator_authorized_github_accounts: []
 
 # NOTE: Use "mkpasswd --method=sha-512" to generate a password
 # operator_password:

--- a/roles/operator/tasks/main.yml
+++ b/roles/operator/tasks/main.yml
@@ -65,6 +65,13 @@
   loop: "{{ operator_authorized_keys }}"
   no_log: true
 
+- name: Set authorized github accounts
+  become: true
+  ansible.posix.authorized_key:
+    key: "{{ lookup('url', 'https://github.com/' + item + '.keys', split_lines=False) }}"
+    user: "{{ operator_user }}"
+  loop: "{{ operator_authorized_github_accounts }}"
+
 - name: Set password of operator user
   become: true
   ansible.builtin.user:


### PR DESCRIPTION
Supports a list of Github accounts from which the public keys are added to the authorized keys.

Related to SovereignCloudStack/issues#433