### PR TITLE
network: reduce permission on /etc/netplan/01-osism.yaml

### DIFF
--- a/releasenotes/notes/netplan-permissions-13170182ceae251f.yaml
+++ b/releasenotes/notes/netplan-permissions-13170182ceae251f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Reduce permission on `/etc/netplan/01-osism.yaml` to avoid
+    `Permissions for /etc/netplan/01-osism.yaml are too open. Netplan
+    configuration should NOT be accessible by others.` warnings.

--- a/roles/network/tasks/type-netplan.yml
+++ b/roles/network/tasks/type-netplan.yml
@@ -43,7 +43,7 @@
   ansible.builtin.template:
     src: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
     dest: "{{ network_netplan_path }}/{{ network_netplan_file }}"
-    mode: 0644
+    mode: 0600
     owner: root
     group: root
   notify:


### PR DESCRIPTION
This will fix the following warning message:

Permissions for /etc/netplan/01-osism.yaml are too open. Netplan configuration should NOT be accessible by others.