### PR TITLE
known_hosts: fix magic groups variable

### DIFF
--- a/roles/known_hosts/defaults/main.yml
+++ b/roles/known_hosts/defaults/main.yml
@@ -9,5 +9,5 @@ operator_group: "{{ operator_user }}"
 # known_hosts
 
 known_hosts_group_name: all
-known_hosts_list: "{{ group[known_hosts_group_name] }}"
+known_hosts_list: "{{ groups[known_hosts_group_name] }}"
 known_hosts_destination: "/home/{{ operator_user }}/.ssh"


### PR DESCRIPTION
Changed by accident with ff592b2db4ccf3e3368117b015e8cbb4d2cd7d98.