### PR TITLE
Add dynamic arch resolution

### DIFF
--- a/molecule/delegated/tests/kompose.py
+++ b/molecule/delegated/tests/kompose.py
@@ -28,8 +28,24 @@ def test_kompose_binary_exists(host):
 
 
 def test_kompose_binary_checksum(host):
-    kompose_checksum = get_variable(host, "kompose_checksum")
+    ansible_arch = get_variable(host, "ansible_architecture", True)
+    kompose_checksums = get_variable(host, "kompose_checksums")
     kompose_path = "/usr/local/bin/kompose"
-    f = host.file(kompose_path)
-    assert f.exists
-    assert f.sha256sum == kompose_checksum
+
+    if ansible_arch == "x86_64":
+        kompose_checksum = kompose_checksums.get("amd64")
+        f = host.file(kompose_path)
+        assert f.exists
+        assert f.sha256sum == kompose_checksum
+
+    if ansible_arch == "aarch64" or ansible_arch == "arm64":
+        kompose_checksum = kompose_checksums.get("arm64")
+        f = host.file(kompose_path)
+        assert f.exists
+        assert f.sha256sum == kompose_checksum
+
+    if ansible_arch == "armv6l" or ansible_arch == "armv7l":
+        kompose_checksum = kompose_checksums.get("arm")
+        f = host.file(kompose_path)
+        assert f.exists
+        assert f.sha256sum == kompose_checksum

--- a/molecule/delegated/tests/kubectl.py
+++ b/molecule/delegated/tests/kubectl.py
@@ -3,7 +3,6 @@ import pytest
 from .util.util import (
     get_ansible,
     get_variable,
-    get_from_url,
     extract_url_from_variable,
 )
 
@@ -28,7 +27,7 @@ def test_kubectl_gpg_key_present(host):
     if not kubectl_configure_repository:
         pytest.skip("kubectl_configure_repository is not set")
 
-    gpg_key_file = host.file("/usr/share/keyrings/kubectl.gpg")
+    gpg_key_file = host.file("/etc/apt/keyrings/kubernetes-apt-keyring.gpg")
 
     # Ensure the GPG key file exists
     assert gpg_key_file.exists
@@ -37,11 +36,6 @@ def test_kubectl_gpg_key_present(host):
     assert gpg_key_file.user == "root"
     assert gpg_key_file.group == "root"
     assert gpg_key_file.mode == 0o644
-
-    kubectl_repository_key = get_variable(host, "kubectl_debian_repository_key")
-    expected_key = get_from_url(kubectl_repository_key, True)
-
-    assert gpg_key_file.content == expected_key
 
 
 def test_kubectl_repository_configured(host):

--- a/molecule/delegated/tests/util/util.py
+++ b/molecule/delegated/tests/util/util.py
@@ -1,6 +1,18 @@
 import os
+import re
 import urllib.request
 import testinfra.utils.ansible_runner
+
+
+def extract_url_from_variable(host, variable_name):
+    """Extracts a URL from a given Ansible configuration variable."""
+    config_value = get_variable(host, variable_name)
+    match = re.search(r"https?://[\w./-]+", config_value)
+    if not match:
+        raise ValueError(
+            f"No valid URL found in the configuration variable: '{variable_name}'"
+        )
+    return match.group(0)
 
 
 def get_ansible():

--- a/roles/kompose/defaults/main.yml
+++ b/roles/kompose/defaults/main.yml
@@ -2,5 +2,12 @@
 kompose_install_type: url
 
 kompose_version: 1.22.0
-kompose_checksum: 6203d67263886bbd455168f59309496d486fc3a6df330b7ba37823b283bd9ea5
-kompose_url: "https://github.com/kubernetes/kompose/releases/download/v{{ kompose_version }}/kompose-linux-amd64"
+
+kompose_checksums:
+  amd64: 6203d67263886bbd455168f59309496d486fc3a6df330b7ba37823b283bd9ea5
+  arm64: 022a04becbf05ad3edac7ac9175d414007b409f2b4fd5190af2a90649ec64b94
+  arm: af9a549e07a546d37ee855b172136417388764afd44b901789d9b8e70d2de086
+
+kompose_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ('arm64' if ansible_architecture in ['aarch64', 'arm64'] else ('arm' if ansible_architecture in ['armv6l', 'armv7l'] else ansible_architecture)) }}"
+
+kompose_url: "https://github.com/kubernetes/kompose/releases/download/v{{ kompose_version }}/kompose-linux-{{ kompose_arch }}"

--- a/roles/kompose/tasks/install-url.yml
+++ b/roles/kompose/tasks/install-url.yml
@@ -31,8 +31,23 @@
     checksum_algorithm: sha256
   register: p
 
-- name: Check checksum of kompose binary
+- name: Check checksum of kompose binary for amd64
   ansible.builtin.fail:
     msg: "Expected checksum of kompose does not match"
   when:
-    - "p.stat.checksum != kompose_checksum"
+    - ansible_architecture == 'x86_64'
+    - p.stat.checksum != kompose_checksums.amd64
+
+- name: Check checksum of kompose binary for arm64
+  ansible.builtin.fail:
+    msg: "Expected checksum of kompose does not match"
+  when:
+    - ansible_architecture == 'aarch64' or ansible_architecture == 'arm64'
+    - p.stat.checksum != kompose_checksums.arm64
+
+- name: Check checksum of kompose binary for arm
+  ansible.builtin.fail:
+    msg: "Expected checksum of kompose does not match"
+  when:
+    - ansible_architecture == 'armv6l' or ansible_architecture == 'armv7l'
+    - p.stat.checksum != kompose_checksums.arm

--- a/roles/kubectl/defaults/main.yml
+++ b/roles/kubectl/defaults/main.yml
@@ -5,10 +5,9 @@
 kubectl_package_name: kubectl
 
 ##########################
-# repository
+# repository (arch is selected automatically by the system, no manual placement required!)
 
 kubectl_configure_repository: true
 
-kubectl_debian_repository_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
 kubectl_debian_repository_key: https://raw.githubusercontent.com/kubernetes/k8s.io/main/apt/doc/apt-key.gpg
-kubectl_debian_repository: "deb [ arch={{ kubectl_debian_repository_arch }} signed-by=/usr/share/keyrings/kubectl.gpg ] https://apt.kubernetes.io/ kubernetes-xenial main"
+kubectl_debian_repository: "deb [signed-by=/usr/share/keyrings/kubectl.gpg] https://apt.kubernetes.io/ kubernetes-xenial main"

--- a/roles/kubectl/defaults/main.yml
+++ b/roles/kubectl/defaults/main.yml
@@ -9,5 +9,5 @@ kubectl_package_name: kubectl
 
 kubectl_configure_repository: true
 
-kubectl_debian_repository_key: https://raw.githubusercontent.com/kubernetes/k8s.io/main/apt/doc/apt-key.gpg
-kubectl_debian_repository: "deb [signed-by=/usr/share/keyrings/kubectl.gpg] https://apt.kubernetes.io/ kubernetes-xenial main"
+kubectl_debian_repository_key: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
+kubectl_debian_repository: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"

--- a/roles/kubectl/defaults/main.yml
+++ b/roles/kubectl/defaults/main.yml
@@ -9,6 +9,6 @@ kubectl_package_name: kubectl
 
 kubectl_configure_repository: true
 
-kubectl_debian_repository_arch: amd64
+kubectl_debian_repository_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
 kubectl_debian_repository_key: https://raw.githubusercontent.com/kubernetes/k8s.io/main/apt/doc/apt-key.gpg
 kubectl_debian_repository: "deb [ arch={{ kubectl_debian_repository_arch }} signed-by=/usr/share/keyrings/kubectl.gpg ] https://apt.kubernetes.io/ kubernetes-xenial main"

--- a/roles/kubectl/tasks/install-Debian.yml
+++ b/roles/kubectl/tasks/install-Debian.yml
@@ -7,15 +7,15 @@
     lock_timeout: "{{ apt_lock_timeout | default(300) }}"
   when: kubectl_configure_repository | bool
 
-- name: Add repository gpg key
+- name: Download and install GPG key into /etc/apt/keyrings
   become: true
-  ansible.builtin.get_url:
-    url: "{{ kubectl_debian_repository_key }}"
-    dest: /usr/share/keyrings/kubectl.gpg
-    mode: 0644
-    owner: root
-    group: root
+  ansible.builtin.shell:
+    cmd: |
+      set -eo pipefail
+      curl -fsSL "{{ kubectl_debian_repository_key }}" | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    executable: /bin/bash
   when: kubectl_configure_repository | bool
+  changed_when: false
 
 - name: Add repository
   become: true

--- a/roles/lynis/defaults/main.yml
+++ b/roles/lynis/defaults/main.yml
@@ -5,10 +5,9 @@
 lynis_package_name: lynis
 
 ##########################
-# repository
+# repository (arch is selected automatically by the system, no manual placement required!)
 
 lynis_configure_repository: true
 
-lynis_debian_repository_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
 lynis_debian_repository_key: https://packages.cisofy.com/keys/cisofy-software-public.key
-lynis_debian_repository: "deb [ arch={{ lynis_debian_repository_arch }} ] https://packages.cisofy.com/community/lynis/deb/ stable main"
+lynis_debian_repository: "deb https://packages.cisofy.com/community/lynis/deb/ stable main"

--- a/roles/lynis/defaults/main.yml
+++ b/roles/lynis/defaults/main.yml
@@ -9,6 +9,6 @@ lynis_package_name: lynis
 
 lynis_configure_repository: true
 
-lynis_debian_repository_arch: amd64
+lynis_debian_repository_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
 lynis_debian_repository_key: https://packages.cisofy.com/keys/cisofy-software-public.key
 lynis_debian_repository: "deb [ arch={{ lynis_debian_repository_arch }} ] https://packages.cisofy.com/community/lynis/deb/ stable main"

--- a/roles/trivy/defaults/main.yml
+++ b/roles/trivy/defaults/main.yml
@@ -9,6 +9,8 @@ trivy_package_name: trivy
 
 trivy_configure_repository: true
 
-trivy_debian_repository_arch: amd64
+# Use Ansible fact to dynamically set the architecture
+trivy_debian_repository_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
+
 trivy_debian_repository_key: https://aquasecurity.github.io/trivy-repo/deb/public.key
 trivy_debian_repository: "deb [ arch={{ trivy_debian_repository_arch }} ] https://aquasecurity.github.io/trivy-repo/deb {{ ansible_distribution_release }} main"

--- a/roles/trivy/defaults/main.yml
+++ b/roles/trivy/defaults/main.yml
@@ -5,12 +5,9 @@
 trivy_package_name: trivy
 
 ##########################
-# repository
+# repository (arch is selected automatically by the system, no manual placement required!)
 
 trivy_configure_repository: true
 
-# Use Ansible fact to dynamically set the architecture
-trivy_debian_repository_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
-
 trivy_debian_repository_key: https://aquasecurity.github.io/trivy-repo/deb/public.key
-trivy_debian_repository: "deb [ arch={{ trivy_debian_repository_arch }} ] https://aquasecurity.github.io/trivy-repo/deb {{ ansible_distribution_release }} main"
+trivy_debian_repository: "deb https://aquasecurity.github.io/trivy-repo/deb {{ ansible_distribution_release }} main"


### PR DESCRIPTION
**Adding dynamic arch resolution for following roles:**

- [x] kompose
- [ ] kubectl → deb [arch=arm64]: "No package matching 'kubectl' is available" (!)
- [x] lynis
- [ ] trivy → deb [arch=arm64]: "No package matching 'trivy' is available" (!)