### PR TITLE
Check target dir exists before writing to it

### DIFF
--- a/roles/network/tasks/type-netplan.yml
+++ b/roles/network/tasks/type-netplan.yml
@@ -59,6 +59,12 @@
   #       changed_when is set to False here.
   changed_when: false
 
+# NOTE: On pure netplan systems, /etc/network as directory might just not exists
+- name: Check if path for interface file exists
+  ansible.builtin.stat:
+    path: "{{ network_interfaces_path }}"
+  register: network_interfaces_path_stat
+
 - name: Copy interfaces file
   become: true
   ansible.builtin.template:
@@ -67,6 +73,7 @@
     mode: 0644
     owner: root
     group: root
+  when: network_interfaces_path_stat.stat.isdir
 
 - name: Copy dispatcher scripts
   become: true


### PR DESCRIPTION
/etc/network is a deprecated interface for network configuration on Ubuntu systems >= 22.04.[1]

As `/etc/network` might not exist, copying the dummy file to it can fail. So checking first if the directory exists is the cleanest way. Another alternative would be to just create `/etc/networks`, but keeping deprecated interfaces just for the sake of deprecated interfaces sounds wrong.

[1]: https://ubuntu.com/server/docs/network-configuration