### PR TITLE
Add dependency for ansible.posix.synchronize

### DIFF
--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -4,6 +4,7 @@ upgrade_packages: true
 required_packages_default:
   - ethtool
   - jq
+  - rsync
   - rsyslog
 
 required_packages_extra: []


### PR DESCRIPTION
`ansible.posix.synchronize` is a wrapper around `rsync`.[1] This module is used in the [`resolveconf role`](https://github.com/osism/ansible-collection-commons/blob/df0305d1ad9a21cd337ee083f2af048fbb33ea54/roles/resolvconf/tasks/configure-resolv.yml#L18).

As `rsync` is now a required dependency for a role, make sure it is actually available on the target system.

Good alternative would be to *just trash the file* on the remote system, because `systemd-resolved` is used nevertheless.

[1]: https://docs.ansible.com/ansible/latest/collections/ansible/posix/synchronize_module.html