### PR TITLE
Add tasks to remove old architecture-dependent repository

### DIFF
--- a/roles/kubectl/tasks/install-Debian.yml
+++ b/roles/kubectl/tasks/install-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 signed-by=/usr/share/keyrings/kubectl.gpg ] https://apt.kubernetes.io/ kubernetes-xenial main"
+    state: absent
+    filename: kubectl
+  when: kubectl_configure_repository|bool
+
 - name: Install apt-transport-https package
   become: true
   ansible.builtin.apt:

--- a/roles/lynis/tasks/install-Debian.yml
+++ b/roles/lynis/tasks/install-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] https://packages.cisofy.com/community/lynis/deb/ stable main"
+    state: absent
+    filename: lynis
+  when: lynis_configure_repository|bool
+
 - name: Install apt-transport-https package
   become: true
   ansible.builtin.apt:

--- a/roles/trivy/tasks/install-Debian.yml
+++ b/roles/trivy/tasks/install-Debian.yml
@@ -1,4 +1,12 @@
 ---
+- name: Remove old architecture-dependent repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [ arch=amd64 ] https://aquasecurity.github.io/trivy-repo/deb {{ ansible_distribution_release }} main"
+    state: absent
+    filename: trivy
+  when: trivy_configure_repository|bool
+
 - name: Install apt-transport-https package
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
cf. https://github.com/osism/issues/issues/849

Add task to remove old repository entry in kubectl, lynis and trivy role (cf. https://github.com/osism/ansible-collection-commons/pull/570)