### PR TITLE
fix unescaped dots in .zuul.yaml

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -48,7 +48,7 @@
     vars:
       ansible_molecule_ansible_version: "9.4.0"
     files:
-      - '^.zuul.yaml$'
+      - '^\.zuul\.yaml$'
       - '^molecule\/delegated\/[^\/]*yml$'
       - '^molecule\/requirements\.txt$'
 


### PR DESCRIPTION
the used regex there works as well, but more so by accident
it would also match e.g. "azuulayaml" files etc.

Signed-off-by: Sven Kieske <kieske@osism.tech>