### PR TITLE
certificates: move certificates_ca_package_name parameter

### DIFF
--- a/molecule/delegated/tests/certificates.py
+++ b/molecule/delegated/tests/certificates.py
@@ -20,7 +20,7 @@ def test_files(host):
 
 
 def test_pkg(host):
-    package_name = get_variable(host, "certificates_ca_package_name")
+    package_name = get_family_role_variable(host, "certificates_ca_package_name")
     package = host.package(package_name)
 
     assert package_name != ""

--- a/roles/certificates/defaults/main.yml
+++ b/roles/certificates/defaults/main.yml
@@ -7,4 +7,3 @@
 #       -----END CERTIFICATE-----
 
 certificates_ca: []
-certificates_ca_package_name: ca-certificates

--- a/roles/certificates/vars/Debian-family.yml
+++ b/roles/certificates/vars/Debian-family.yml
@@ -1,3 +1,4 @@
 ---
 certificates_ca_path: /usr/local/share/ca-certificates
 certificates_ca_update_command: /usr/sbin/update-ca-certificates
+certificates_ca_package_name: ca-certificates

--- a/roles/certificates/vars/RedHat-family.yml
+++ b/roles/certificates/vars/RedHat-family.yml
@@ -1,3 +1,4 @@
 ---
 certificates_ca_path: /etc/pki/ca-trust/extracted/pem
 certificates_ca_update_command: /usr/bin/update-ca-trust
+certificates_ca_package_name: ca-certificates


### PR DESCRIPTION
The certificates_ca_package_name can be an OS specific parameter that cannot be changed.