### PR TITLE
sshconfig: allow to skip "Ensure config for each host exist"

### DIFF
--- a/roles/sshconfig/tasks/main.yml
+++ b/roles/sshconfig/tasks/main.yml
@@ -23,7 +23,10 @@
     src: config.j2
     dest: "{{ sshconfig_destination.stdout }}/.ssh/config.d/{{ sshconfig_order }}-{{ hostvars[item].inventory_hostname_short }}"
     mode: 0600
-  when: item != "localhost" and item != "127.0.0.1"
+  when:
+    - item != "localhost"
+    - item != "127.0.0.1"
+    - sshconfig_private_key_file | length > 0
   loop: "{{ groups[sshconfig_groupname] }}"
 
 - name: Add extra config


### PR DESCRIPTION
By setting sshconfig_private_key_file = "" it's possible to skip the "Ensure config for each host exist" task. This way it's possible to use the role to only write extra ssh config.

This is necessary if you initially set up the manager from the seed and have to configure certain SSH parameters to reach the Git server.