### PR TITLE
operator: make it possible to delete authorized keys

### DIFF
--- a/roles/operator/defaults/main.yml
+++ b/roles/operator/defaults/main.yml
@@ -8,7 +8,11 @@ operator_group_id: 45000
 operator_shell: /bin/bash
 
 operator_authorized_keys: []
+operator_authorized_keys_delete: []
+
 operator_authorized_github_accounts: []
+operator_authorized_github_accounts_delete: []
+
 operator_authorized_keys_minimal: 0
 
 # NOTE: Use "mkpasswd --method=sha-512" to generate a password

--- a/roles/operator/tasks/main.yml
+++ b/roles/operator/tasks/main.yml
@@ -75,12 +75,29 @@
   loop: "{{ operator_authorized_keys }}"
   no_log: true
 
+- name: Delete ssh authorized keys
+  become: true
+  ansible.posix.authorized_key:
+    key: "{{ item }}"
+    user: "{{ operator_user }}"
+    state: absent
+  loop: "{{ operator_authorized_keys_delete }}"
+  no_log: true
+
 - name: Set authorized github accounts
   become: true
   ansible.posix.authorized_key:
     key: "{{ lookup('url', 'https://github.com/' + item + '.keys', split_lines=False) }}"
     user: "{{ operator_user }}"
   loop: "{{ operator_authorized_github_accounts }}"
+
+- name: Delete authorized github accounts
+  become: true
+  ansible.posix.authorized_key:
+    key: "{{ lookup('url', 'https://github.com/' + item + '.keys', split_lines=False) }}"
+    user: "{{ operator_user }}"
+    state: absent
+  loop: "{{ operator_authorized_github_accounts_delete }}"
 
 - name: Set password of operator user
   become: true


### PR DESCRIPTION
With operator_authorized_keys_delete and operator_authorized_github_accounts_delete it is possible to delete keys from the authorized keys file.