### PR TITLE
known_hosts: make it possible to delete entries

### DIFF
--- a/roles/known_hosts/defaults/main.yml
+++ b/roles/known_hosts/defaults/main.yml
@@ -14,3 +14,4 @@ known_hosts_destination: "/home/{{ operator_user }}/.ssh"
 
 known_hosts: []
 known_hosts_extra: []
+known_hosts_delete: []

--- a/roles/known_hosts/tasks/main.yml
+++ b/roles/known_hosts/tasks/main.yml
@@ -52,6 +52,17 @@
     - known_hosts_extra is defined
     - known_hosts_extra | length
 
+- name: Delete known_hosts entries
+  ansible.builtin.known_hosts:
+    path: "{{ known_hosts_destination }}/known_hosts"
+    name: "{{ item.split(' ') | first }}"
+    key: "{{ item }}"
+    state: absent
+  loop: "{{ known_hosts_delete }}"
+  when:
+    - known_hosts_delete is defined
+    - known_hosts_delete | length
+
 - name: Set file permissions
   ansible.builtin.file:
     path: "{{ known_hosts_destination }}/known_hosts"


### PR DESCRIPTION
With known_hosts_delete it is possible to delete entries from the known_hosts file.