### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/add-molecule-testinfra-2d1589b440392f7d.yaml
+++ b/releasenotes/notes/add-molecule-testinfra-2d1589b440392f7d.yaml
@@ -1,4 +1,0 @@
----
-other:
-  - |
-    Added unittests for Molecule delegated scenario with testinfra (molecule/delegated/tests)

--- a/releasenotes/notes/add-molecule-zuul-job-4733139d7df31f65.yaml
+++ b/releasenotes/notes/add-molecule-zuul-job-4733139d7df31f65.yaml
@@ -1,7 +1,0 @@
----
-other:
-  - |
-    After adding Ansible Molecule job to osim/zuul-jobs repository (#50)
-    GitHub Workflows for test roles are no longer required and has been
-    removed (.github/workflows/test-role-*). For each test role a job was
-    created in .zuul.yaml.

--- a/releasenotes/notes/add-redhat-implementation-8e9e9a5b93dd7bb6.yaml
+++ b/releasenotes/notes/add-redhat-implementation-8e9e9a5b93dd7bb6.yaml
@@ -1,4 +1,0 @@
----
-other:
-  - |
-    Added CentOS Stream 9 compatibility to Ansible roles and Molecule tests

--- a/releasenotes/notes/docker-compose-osism-target-59a57cb00e7502a3.yaml
+++ b/releasenotes/notes/docker-compose-osism-target-59a57cb00e7502a3.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    All docker-compose services are now added to an osism target. So it
-    is possible to stop all OSISM service via this target.

--- a/releasenotes/notes/docker-compose-service-simple-5b5b79435ad8391f.yaml
+++ b/releasenotes/notes/docker-compose-service-simple-5b5b79435ad8391f.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    For the Docker Compose systemd unit, the type simple is now used
-    instead of oneshot. This allows more logs to be retrieved.

--- a/releasenotes/notes/fix-netplan-permissions-547-f7c6028bf2d158dd.yaml
+++ b/releasenotes/notes/fix-netplan-permissions-547-f7c6028bf2d158dd.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Change permission of the created netplan file from 644 to 600.

--- a/releasenotes/notes/limits-516d3a18b094046f.yaml
+++ b/releasenotes/notes/limits-516d3a18b094046f.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    With osism.commons.limits it is possible to manage PAM limits.

--- a/releasenotes/notes/netplan-permissions-13170182ceae251f.yaml
+++ b/releasenotes/notes/netplan-permissions-13170182ceae251f.yaml
@@ -1,6 +1,0 @@
----
-fixes:
-  - |
-    Reduce permission on `/etc/netplan/01-osism.yaml` to avoid
-    `Permissions for /etc/netplan/01-osism.yaml are too open. Netplan
-    configuration should NOT be accessible by others.` warnings.

--- a/releasenotes/notes/network-default-netplan-dda52e88b415f4f2.yaml
+++ b/releasenotes/notes/network-default-netplan-dda52e88b415f4f2.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Default network type in the network role is now netplan.

--- a/releasenotes/notes/operator_authorized_keys_minimal-6379a5c583625bef.yaml
+++ b/releasenotes/notes/operator_authorized_keys_minimal-6379a5c583625bef.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    In the operator role, it is now possible to check the minimum number
-    of SSH authorized keys set with `operator_authorized_keys_minimal`. If
-    fewer are set, the role fails. In order not to change the default
-    behaviour, `operator_authorized_keys_minimal` is set to `0` by default.

--- a/releasenotes/notes/repository-check-if-manager-is-there-6a748edc89deb5d1.yaml
+++ b/releasenotes/notes/repository-check-if-manager-is-there-6a748edc89deb5d1.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    In osism.common.repository only check for the existence of key files in
-    the configuration repository when there is at least one manager. This way
-    it is possible to re-use the role outside of OSISM without annoying error
-    messages.

--- a/releasenotes/notes/still-alive-callback-plugin-7dd0a0eca15fc4ce.yaml
+++ b/releasenotes/notes/still-alive-callback-plugin-7dd0a0eca15fc4ce.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    The `still_alive` callback stdout plugin displays a banner every
-    30 seconds when a task is running more than 120 seconds. This way
-    a user can be informed about long running tasks without touching
-    existing tasks.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.