### PR TITLE
Change permissions for checkout folder

### DIFF
--- a/molecule/delegated/tests/configuration/main.py
+++ b/molecule/delegated/tests/configuration/main.py
@@ -9,7 +9,7 @@ def check_file_attributes(host, path):
     assert f.is_directory
     assert f.user == get_variable(host, "operator_user")
     assert f.group == get_variable(host, "operator_group")
-    assert f.mode == 0o750
+    assert f.mode == 0o770
 
 
 def test_folders(host):

--- a/roles/configuration/tasks/git.yml
+++ b/roles/configuration/tasks/git.yml
@@ -72,9 +72,9 @@
   no_log: true
   tags: update-configuration
 
-- name: Set permissions and owner for checkout
+- name: Git - set permissions of configuration directory
   ansible.builtin.file:
     path: "{{ configuration_directory }}"
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
-    mode: '0770'
+    mode: 0770

--- a/roles/configuration/tasks/git.yml
+++ b/roles/configuration/tasks/git.yml
@@ -53,6 +53,7 @@
     version: "{{ configuration_git_version }}"
     key_file: "{{ configuration_git_private_key_file }}"
     accept_hostkey: true
+    umask: "0007"
     force: true
   when: configuration_git_protocol == 'ssh'
   tags: update-configuration
@@ -64,8 +65,16 @@
     version: "{{ configuration_git_version }}"
     accept_hostkey: true
     force: true
+    umask: "0007"
   when: (configuration_git_protocol == 'ssh' and (configuration_git_private_key is not defined or not configuration_git_private_key | length)) or
         configuration_git_protocol != 'ssh'
   # NOTE: No logs are output to avoid leaking a PAT if it is used as a username.
   no_log: true
   tags: update-configuration
+
+- name: Set permissions and owner for checkout
+  ansible.builtin.file:
+    path: "{{ configuration_directory }}"
+    owner: "{{ operator_user }}"
+    group: "{{ operator_group }}"
+    mode: '0770'


### PR DESCRIPTION
https://docs.ansible.com/ansible/2.9/modules/git_module.html currently sets 0750 for the toplevel directory
(according to predefined umask). Setting "umask" alone is not enough, it seems that a "umask" on " ansible.builtin.git" only affects the file contained in the clone directory.