### PR TITLE
kubectl: install python3-kubernetes on Debian-based distros

### DIFF
--- a/roles/kubectl/vars/Debian-family.yml
+++ b/roles/kubectl/vars/Debian-family.yml
@@ -1,6 +1,4 @@
 ---
-##########################
-# packages
-
 kubectl_required_packages:
   - kubectl
+  - python3-kubernetes

--- a/roles/kubectl/vars/RedHat-family.yml
+++ b/roles/kubectl/vars/RedHat-family.yml
@@ -1,6 +1,3 @@
 ---
-##########################
-# packages
-
 kubectl_required_packages:
   - kubectl


### PR DESCRIPTION
Is needed so that you can also use Ansible kubernetes.core modules on the manager. The package for RedHat based distros will be added later. To do this, the EPEL repository must first be made available, for which the osism.commons.repository role must first be extended.