### PR TITLE
Show motd on ssh login

### DIFF
--- a/roles/motd/defaults/main.yml
+++ b/roles/motd/defaults/main.yml
@@ -2,3 +2,4 @@
 issue_path: /etc/issue
 motd_path: /etc/motd
 motd_content: ""
+motd_show_ssh: false

--- a/roles/motd/handlers/main.yml
+++ b/roles/motd/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 # handlers file for motd
-- name: Reload sshd to make motd changes effective
+- name: Reload ssh service to make motd changes effective
   become: true
   ansible.builtin.service:
     name: "ssh"

--- a/roles/motd/handlers/main.yml
+++ b/roles/motd/handlers/main.yml
@@ -1,7 +1,6 @@
 ---
-# handlers file for motd
-- name: Reload ssh service to make motd changes effective
+- name: Reload ssh service
   become: true
   ansible.builtin.service:
-    name: "ssh"
+    name: ssh
     state: reloaded

--- a/roles/motd/handlers/main.yml
+++ b/roles/motd/handlers/main.yml
@@ -1,3 +1,4 @@
+---
 # handlers file for motd
 - name: Reload sshd to make motd changes effective
   become: true

--- a/roles/motd/handlers/main.yml
+++ b/roles/motd/handlers/main.yml
@@ -1,0 +1,6 @@
+# handlers file for motd
+- name: Reload sshd to make motd changes effective
+  become: true
+  ansible.builtin.service:
+    name: "ssh"
+    state: reloaded

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -36,24 +36,3 @@
     state: absent
     name: "{{ item.path | ansible.builtin.basename }}"
   loop: "{{ etc_pam_motd.files }}"
-
-- name: Configure SSH to print the motd
-  become: true
-  ansible.builtin.copy:
-    dest: /etc/ssh/sshd_config.d/60-motd.conf
-    content: |
-       # Shows the motd on every ssh login
-       PrintMotd yes
-    group: root
-    owner: root
-    mode: 0644
-  notify: Reload ssh service to make motd changes effective
-  when: motd_show_ssh | bool
-
-- name: Configure SSH to not print the motd
-  become: true
-  ansible.builtin.file:
-    path: /etc/ssh/sshd_config.d/60-motd.conf
-    state: absent
-  notify: Reload ssh service to make motd changes effective
-  when: not motd_show_ssh | bool

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -42,10 +42,11 @@
   ansible.builtin.copy:
     dest: /etc/ssh/sshd_config.d/60-motd.conf
     content: |
+       # Shows the motd on every ssh login
        PrintMotd yes
     group: root
     owner: root
-    mode: 0644
+    mode: "0644"
   notify: Reload sshd to make motd changes effective
   when: motd_show_ssh | bool
 

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -44,7 +44,7 @@
     content: |
        PrintMotd yes
   notify: Reload sshd to make motd changes effective
-  when: motd_show_ssh == true
+  when: motd_show_ssh | bool
 
 - name: Configure SSH to not print the motd
   become: true
@@ -52,5 +52,5 @@
     path: /etc/ssh/sshd_config.d/60-motd.conf
     state: absent
   notify: Reload sshd to make motd changes effective
-  when: motd_show_ssh != true
+  when: not motd_show_ssh | bool
 

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -38,9 +38,19 @@
   loop: "{{ etc_pam_motd.files }}"
 
 - name: Configure SSH to print the motd
+  become: true
   copy:
     dest: /etc/ssh/sshd_config.d/60-motd.conf
     content: |
        PrintMotd yes
   notify: Reload sshd to make motd changes effective
+  when: motd_show_ssh == true
+
+- name: Configure SSH to not print the motd
+  become: true
+  file:
+    path: /etc/ssh/sshd_config.d/60-motd.conf
+    state: absent
+  notify: Reload sshd to make motd changes effective
+  when: motd_show_ssh != true
 

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -47,7 +47,7 @@
     group: root
     owner: root
     mode: "0644"
-  notify: Reload sshd to make motd changes effective
+  notify: Reload ssh service to make motd changes effective
   when: motd_show_ssh | bool
 
 - name: Configure SSH to not print the motd
@@ -55,5 +55,5 @@
   ansible.builtin.file:
     path: /etc/ssh/sshd_config.d/60-motd.conf
     state: absent
-  notify: Reload sshd to make motd changes effective
+  notify: Reload ssh service to make motd changes effective
   when: not motd_show_ssh | bool

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -45,7 +45,7 @@
        PrintMotd yes
     group: root
     owner: root
-    mode: 644
+    mode: 0644
   notify: Reload sshd to make motd changes effective
   when: motd_show_ssh | bool
 

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -46,7 +46,7 @@
        PrintMotd yes
     group: root
     owner: root
-    mode: "0644"
+    mode: 0644
   notify: Reload ssh service to make motd changes effective
   when: motd_show_ssh | bool
 

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -39,18 +39,20 @@
 
 - name: Configure SSH to print the motd
   become: true
-  copy:
+  ansible.builtin.copy:
     dest: /etc/ssh/sshd_config.d/60-motd.conf
     content: |
        PrintMotd yes
+    group: root
+    owner: root
+    mode: 644
   notify: Reload sshd to make motd changes effective
   when: motd_show_ssh | bool
 
 - name: Configure SSH to not print the motd
   become: true
-  file:
+  ansible.builtin.file:
     path: /etc/ssh/sshd_config.d/60-motd.conf
     state: absent
   notify: Reload sshd to make motd changes effective
   when: not motd_show_ssh | bool
-

--- a/roles/motd/tasks/configure-Debian-family.yml
+++ b/roles/motd/tasks/configure-Debian-family.yml
@@ -36,3 +36,11 @@
     state: absent
     name: "{{ item.path | ansible.builtin.basename }}"
   loop: "{{ etc_pam_motd.files }}"
+
+- name: Configure SSH to print the motd
+  copy:
+    dest: /etc/ssh/sshd_config.d/60-motd.conf
+    content: |
+       PrintMotd yes
+  notify: Reload sshd to make motd changes effective
+

--- a/roles/motd/tasks/main.yml
+++ b/roles/motd/tasks/main.yml
@@ -19,3 +19,24 @@
     owner: root
     group: root
     mode: 0644
+
+- name: Configure SSH to print the motd
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/ssh/sshd_config.d/60-motd.conf
+    content: |
+       # Prints the motd on every SSH login
+       PrintMotd yes
+    group: root
+    owner: root
+    mode: 0644
+  notify: Reload ssh service
+  when: motd_show_ssh | bool
+
+- name: Configure SSH to not print the motd
+  become: true
+  ansible.builtin.file:
+    path: /etc/ssh/sshd_config.d/60-motd.conf
+    state: absent
+  notify: Reload ssh service
+  when: not motd_show_ssh | bool


### PR DESCRIPTION
Currently the motd is not displayed when performing a SSH login.

As logins in CSP environments are primarily carried out via SSH, we activate this here, as otherwise the configuration of a Motd would make little sense. This change ignores Redhat environments, because i do not have access to such a environment.