### PR TITLE
packages: move "Set apt_cache_valid_time variable to default value"

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -7,10 +7,5 @@
     required_packages_distribution: "{{ __required_packages_distribution }}"
   when: required_packages_distribution|default(None) == None
 
-- name: Set apt_cache_valid_time variable to default value
-  ansible.builtin.set_fact:
-    apt_cache_valid_time: "{{ __apt_cache_valid_time }}"
-  when: apt_cache_valid_time|default(None) == None
-
 - name: Include distribution specific package tasks
   ansible.builtin.include_tasks: "package-{{ ansible_os_family }}-family.yml"

--- a/roles/packages/tasks/package-Debian-family.yml
+++ b/roles/packages/tasks/package-Debian-family.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set apt_cache_valid_time variable to default value
+  ansible.builtin.set_fact:
+    apt_cache_valid_time: "{{ __apt_cache_valid_time }}"
+  when: apt_cache_valid_time|default(None) == None
+
 - name: Update package cache
   become: true
   ansible.builtin.apt:


### PR DESCRIPTION
This task is only necessary when using the role on Debian.