### PR TITLE
Packages: Add lvm2 to required_packages_default

### DIFF
--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -8,6 +8,7 @@ required_packages_default:
   - iotop
   - jq
   - lsscsi
+  - lvm2
   - ltrace
   - mtr
   - nvme-cli


### PR DESCRIPTION
The `lvm2` package is not installed by default on CentOS and Debian, but required by `/opt/configuration/scripts/deploy/100-ceph-services.sh`.