### PR TITLE
network: add dummy-devices

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -105,6 +105,7 @@ network_renderer: networkd
 
 network_bonds: {}
 network_bridges: {}
+network_dummy_devices: {}
 network_ethernets: {}
 network_tunnels: {}
 network_vlans: {}

--- a/roles/network/templates/netplan/01-osism.yaml.j2
+++ b/roles/network/templates/netplan/01-osism.yaml.j2
@@ -11,6 +11,9 @@ network:
   bridges:
     {{ network_bridges|to_nice_yaml(indent=4)|indent(4) }}
 
+  dummy-devices:
+    {{ network_dummy_devices|to_nice_yaml(indent=4)|indent(4) }}
+
   ethernets:
     {{ network_ethernets|to_nice_yaml(indent=4)|indent(4) }}
 


### PR DESCRIPTION
With network_dummy_devices it is possible to configure dummy devices.

https://netplan.readthedocs.io/en/latest/netplan-yaml/#properties-for-device-type-dummy-devices