### PR TITLE
packages: make needrestart mode configurable

### DIFF
--- a/molecule/delegated/tests/packages/debian.py
+++ b/molecule/delegated/tests/packages/debian.py
@@ -10,7 +10,7 @@ def check_ansible_os_family(host):
         pytest.skip("ansible_os_family mismatch")
 
 
-def test_package_upgrade(host):
+def test_packages_upgrade(host):
     check_ansible_os_family(host)
 
     upgrade_packages = get_variable(host, "upgrade_packages")
@@ -22,3 +22,16 @@ def test_package_upgrade(host):
     # subtract 1 to account for the header line
     num_upgradable = int(upgradable.strip()) - 1
     assert num_upgradable == 0
+
+
+def test_packages_needrestart_mode(host):
+    check_ansible_os_family(host)
+
+    packages_needrestart_mode = get_variable(host, "packages_needrestart_mode")
+    needrestart_configuration = host.file(
+        "/etc/needrestart/needrestart.conf"
+    ).content_string
+    assert (
+        f"$nrconf{{restart}} = '{packages_needrestart_mode}';"
+        in needrestart_configuration
+    )

--- a/molecule/delegated/tests/packages/main.py
+++ b/molecule/delegated/tests/packages/main.py
@@ -8,7 +8,7 @@ from ..util.util import (
 testinfra_runner, testinfra_hosts = get_ansible()
 
 
-def test_required_packages_installed(host):
+def test_packages_required(host):
     required_packages = get_variable(host, "required_packages")
     required_packages_default = get_variable(host, "required_packages_default")
     required_packages_extra = get_variable(host, "required_packages_extra")

--- a/molecule/delegated/tests/packages/redhat.py
+++ b/molecule/delegated/tests/packages/redhat.py
@@ -10,7 +10,7 @@ def check_ansible_os_family(host):
         pytest.skip("ansible_os_family mismatch")
 
 
-def test_package_upgrade(host):
+def test_packages_upgrade(host):
     check_ansible_os_family(host)
 
     upgrade_packages = get_variable(host, "upgrade_packages")

--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+packages_needrestart_mode: l
+
 upgrade_packages: true
 
 required_packages_default:

--- a/roles/packages/tasks/package-Debian-family.yml
+++ b/roles/packages/tasks/package-Debian-family.yml
@@ -1,4 +1,18 @@
 ---
+- name: Install needrestart package
+  become: true
+  ansible.builtin.apt:
+    name: needrestart
+    state: present
+    lock_timeout: "{{ apt_lock_timeout | default(300) }}"
+
+- name: Set needrestart mode
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/needrestart/needrestart.conf
+    regexp: "^#$nrconf{restart} = 'i';"
+    line: "$nrconf{restart} = '{{ packages_needrestart_mode }}';"
+
 - name: Set apt_cache_valid_time variable to default value
   ansible.builtin.set_fact:
     apt_cache_valid_time: "{{ __apt_cache_valid_time }}"


### PR DESCRIPTION
With the packages_needstart_mode it is possible to change the needstart mode. Possible values are a (auto), i (interactive) and l (list only).

The default value is l (list only). The Ubuntu default is i (interactive). We prefer to only list services that should be restarted.