### PR TITLE
network: only use dummy-devices on ubuntu >= 24.04

### DIFF
--- a/roles/network/templates/netplan/01-osism.yaml.j2
+++ b/roles/network/templates/netplan/01-osism.yaml.j2
@@ -11,8 +11,10 @@ network:
   bridges:
     {{ network_bridges|to_nice_yaml(indent=4)|indent(4) }}
 
+{% if ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '>=') %}
   dummy-devices:
     {{ network_dummy_devices|to_nice_yaml(indent=4)|indent(4) }}
+{% endif %}
 
   ethernets:
     {{ network_ethernets|to_nice_yaml(indent=4)|indent(4) }}


### PR DESCRIPTION
dummy-devices only usable with netplan >= 0.107