### PR TITLE
packages: install isc-dhcp-client on Debian/Ubuntu

### DIFF
--- a/roles/packages/vars/Debian-family.yml
+++ b/roles/packages/vars/Debian-family.yml
@@ -8,6 +8,7 @@ __required_packages_distribution:
   - htop
   - iftop
   - iperf
+  - isc-dhcp-client
   - multitail
   - ncdu
   - pv


### PR DESCRIPTION
The /sbin/dhclient binary is required by the octavia-interface.service and is not installed by default on Debian.