### PR TITLE
packages: install git by default

### DIFF
--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -7,11 +7,12 @@ required_packages_default:
   - curl
   - dmidecode
   - ethtool
+  - git
   - iotop
   - jq
   - lsscsi
-  - lvm2
   - ltrace
+  - lvm2
   - mtr
   - nvme-cli
   - pciutils


### PR DESCRIPTION
Will be required in future to be able to execute prepared plays directly on the node and to be able to manage static configurations on the nodes in a central Git repository.