### PR TITLE
proxy: add proxy_enable parameter

### DIFF
--- a/roles/proxy/defaults/main.yml
+++ b/roles/proxy/defaults/main.yml
@@ -14,3 +14,5 @@ proxy_no_proxy: "{{ proxy_no_proxy_default + proxy_no_proxy_extra }}"
 
 proxy_package_manager: true
 proxy_apt_conf_path: /etc/apt/apt.conf.d/01proxy
+
+proxy_enable: true

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Include distribution specific tasks
   ansible.builtin.include_tasks: "{{ ansible_os_family }}-family.yml"
   when:
+    - proxy_enable | bool
     - proxy_package_manager | bool
     - proxy_proxies
 
@@ -25,7 +26,9 @@
 
       no_proxy={{ proxy_no_proxy | join(',') }}
       NO_PROXY={{ proxy_no_proxy | join(',') }}
-  when: proxy_proxies
+  when:
+    - proxy_enable | bool
+    - proxy_proxies
 
 - name: Remove system wide settings in environment file
   become: true
@@ -33,4 +36,6 @@
     dest: /etc/environment
     marker: "# {mark} ANSIBLE MANAGED BLOCK (osism.proxy)"
     state: absent
-  when: not proxy_proxies
+  when:
+    - proxy_enable | bool
+    - not proxy_proxies


### PR DESCRIPTION
With the proxy_enable parameter it is possible to disable the proxy configuration. This makes it easier to configure global proxy parameters (via environment or group_vasr) and to skip them via host_vars only for specific hosts.