### PR TITLE
sysctl: fs.inotify.max_user_instances = 1024 @ k3s_node

### DIFF
--- a/roles/sysctl/defaults/main.yml
+++ b/roles/sysctl/defaults/main.yml
@@ -31,5 +31,9 @@ sysctl_defaults:
   compute:
     - name: net.netfilter.nf_conntrack_max
       value: 1048576
+  # https://gitlab.com/yaook/operator/-/commit/1e42eda64fac8045baeae1d88e865c5db70cc25b
+  k3s_node:
+    - name: fs.inotify.max_user_instances
+      value: 1024
 
 sysctl_extra: {}


### PR DESCRIPTION
Related to https://gitlab.com/yaook/operator/-/commit/1e42eda64fac8045baeae1d88e865c5db70cc25b

Closes osism/issues#1155