### PR TITLE
update kubectl to current release

### DIFF
--- a/roles/kubectl/defaults/main.yml
+++ b/roles/kubectl/defaults/main.yml
@@ -4,8 +4,11 @@
 
 kubectl_configure_repository: true
 
-kubectl_debian_repository_key: https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key
-kubectl_debian_repository: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /"
+# Review the following url for the current installation instructions
+# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
+# (Update key and release if changed)
+kubectl_debian_repository_key: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
+kubectl_debian_repository: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /"
 
-kubectl_redhat_repository_key: https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key
-kubectl_redhat_repository: "https://pkgs.k8s.io/core:/stable:/v1.30/rpm/"
+kubectl_redhat_repository_key: https://pkgs.k8s.io/core:/stable:/v1.32/rpm/repodata/repomd.xml.key
+kubectl_redhat_repository: "https://pkgs.k8s.io/core:/stable:/v1.32/rpm/"

--- a/roles/kubectl/tasks/install-Debian-family.yml
+++ b/roles/kubectl/tasks/install-Debian-family.yml
@@ -20,7 +20,8 @@
   ansible.builtin.shell:
     cmd: |
       set -eo pipefail
-      curl -fsSL {{ kubectl_debian_repository_key }} | gpg --dearmor --batch --no-tty -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      curl -fsSL {{ kubectl_debian_repository_key }} | gpg --dearmor --batch --no-tty -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg-new
+      mv /etc/apt/keyrings/kubernetes-apt-keyring.gpg-new /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     executable: /bin/bash
     creates: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
   when: kubectl_configure_repository | bool


### PR DESCRIPTION
- raise version to current 1.32 release
- drop previous gpg keys before adding the new key to prevent an occured validation problem