### PR TITLE
network: allow to create vxlan interfaces

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -119,10 +119,17 @@ network_dispatcher_scripts: []
 #   - src: /opt/configuration/network/iptables.sh
 #     dest: routable.d/iptables.sh
 
-# dummy
-
 ## network_dummy_interfaces:
 ##   - lo-bgp
 ##   - lo-vxlan
 network_dummy_interfaces: []
 network_dummy_interface_mtu: 9000
+
+## network_vxlan_interfaces:
+##   - name: vxlan123
+##     vni: 123
+##     local_ip: 10.10.0.1
+##     dests:
+##       - 10.10.0.2
+##       - 10.10.0.3
+network_vxlan_interfaces: []

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -8,3 +8,7 @@
 - name: Include dummy interfaces
   ansible.builtin.include_tasks: dummy-interfaces.yml
   when: network_dummy_interfaces | length > 0
+
+- name: Include vxlan interfaces
+  ansible.builtin.include_tasks: vxlan-interfaces.yml
+  when: network_vxlan_interfaces | length > 0

--- a/roles/network/tasks/vxlan-interfaces.yml
+++ b/roles/network/tasks/vxlan-interfaces.yml
@@ -1,0 +1,19 @@
+---
+- name: Create systemd networkd netdev files
+  become: true
+  ansible.builtin.template:
+    src: vxlan.netdev.j2
+    dest: "/etc/systemd/network/3{{ item.0 }}-{{ item.1 }}.netdev"
+    mode: 0644
+    owner: root
+    group: root
+  with_indexed_items: "{{ network_vxlan_interfaces }}"
+- name: Create systemd networkd network files
+  become: true
+  ansible.builtin.template:
+    src: vxlan.network.j2
+    dest: "/etc/systemd/network/3{{ item.0 }}-{{ item.1 }}.network"
+    mode: 0644
+    owner: root
+    group: root
+  with_indexed_items: "{{ network_vxlan_interfaces }}"

--- a/roles/network/templates/vxlan.netdev.j2
+++ b/roles/network/templates/vxlan.netdev.j2
@@ -1,0 +1,11 @@
+[NetDev]
+Name={{ item.1.name }}
+Kind=vxlan
+MTUBytes=1500
+
+[VXLAN]
+VNI={{ item.1.vni }}
+Local={{ item.1.local_ip }}
+MacLearning=true
+DestinationPort=4789
+Independent=yes

--- a/roles/network/templates/vxlan.network.j2
+++ b/roles/network/templates/vxlan.network.j2
@@ -1,0 +1,11 @@
+[Match]
+Name={{ item.1.name }}
+
+[Network]
+IPv6AcceptRA=no
+{% for dest in item.1.dests %}
+
+[BridgeFDB]
+MACAddress=00:00:00:00:00:00
+Destination={{ dest }}
+{% endfor %}


### PR DESCRIPTION
Sadly netplan doesn't allow to create vxlan interfaces so we create the netdev/network files for systemd-networkd directly.