### PR TITLE
Fix vxlan networkd unit names

### DIFF
--- a/roles/network/tasks/vxlan-interfaces.yml
+++ b/roles/network/tasks/vxlan-interfaces.yml
@@ -3,7 +3,7 @@
   become: true
   ansible.builtin.template:
     src: vxlan.netdev.j2
-    dest: "/etc/systemd/network/3{{ item.0 }}-{{ item.1 }}.netdev"
+    dest: "/etc/systemd/network/3{{ item.0 }}-{{ item.1.name }}.netdev"
     mode: 0644
     owner: root
     group: root
@@ -12,7 +12,7 @@
   become: true
   ansible.builtin.template:
     src: vxlan.network.j2
-    dest: "/etc/systemd/network/3{{ item.0 }}-{{ item.1 }}.network"
+    dest: "/etc/systemd/network/3{{ item.0 }}-{{ item.1.name }}.network"
     mode: 0644
     owner: root
     group: root


### PR DESCRIPTION
Use the `name` key from the second element of the loop variable dictionary instead of the dictionary itself as part of the unit file name.