### PR TITLE
Restructure vxlan definitions

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -129,7 +129,7 @@ network_dummy_interfaces: []
 network_dummy_interface_mtu: 9000
 
 ## network_vxlan_interfaces:
-##   - name: vxlan123
+##   vxlan123:
 ##     vni: 123
 ##     local_ip: 10.10.0.1
 ##     dests:
@@ -137,4 +137,4 @@ network_dummy_interface_mtu: 9000
 ##       - 10.10.0.3
 ##     addresses:  # optional list of interface addresses
 ##       - 192.168.1.1/24
-network_vxlan_interfaces: []
+network_vxlan_interfaces: {}

--- a/roles/network/tasks/vxlan-interfaces.yml
+++ b/roles/network/tasks/vxlan-interfaces.yml
@@ -3,21 +3,21 @@
   become: true
   ansible.builtin.template:
     src: vxlan.netdev.j2
-    dest: "/etc/systemd/network/3{{ item.0 }}-{{ item.1.name }}.netdev"
+    dest: "/etc/systemd/network/30-{{ item.key }}.netdev"
     mode: 0644
     owner: root
     group: root
-  with_indexed_items: "{{ network_vxlan_interfaces }}"
+  loop: "{{ network_vxlan_interfaces | dict2items }}"
   register: network_vxlan_interfaces_netdev_files
   notify: Reload systemd-networkd
 - name: Create systemd networkd network files
   become: true
   ansible.builtin.template:
     src: vxlan.network.j2
-    dest: "/etc/systemd/network/3{{ item.0 }}-{{ item.1.name }}.network"
+    dest: "/etc/systemd/network/30-{{ item.key }}.network"
     mode: 0644
     owner: root
     group: root
-  with_indexed_items: "{{ network_vxlan_interfaces }}"
+  loop: "{{ network_vxlan_interfaces | dict2items }}"
   notify: Reload systemd-networkd
   register: network_vxlan_interfaces_network_files

--- a/roles/network/templates/vxlan.netdev.j2
+++ b/roles/network/templates/vxlan.netdev.j2
@@ -1,11 +1,11 @@
 [NetDev]
-Name={{ item.1.name }}
+Name={{ item.key }}
 Kind=vxlan
 MTUBytes=1500
 
 [VXLAN]
-VNI={{ item.1.vni }}
-Local={{ item.1.local_ip }}
+VNI={{ item.value.vni }}
+Local={{ item.value.local_ip }}
 MacLearning=true
 DestinationPort=4789
 Independent=yes

--- a/roles/network/templates/vxlan.network.j2
+++ b/roles/network/templates/vxlan.network.j2
@@ -1,14 +1,14 @@
 [Match]
-Name={{ item.1.name }}
+Name={{ item.key }}
 
 [Network]
 IPv6AcceptRA=no
-{% if 'addresses' in item.1 -%}
-{%  for address in item.1.addresses %}
+{% if 'addresses' in item.value -%}
+{%  for address in item.value.addresses %}
 Address={{ address }}
 {% endfor %}
 {% endif %}
-{% for dest in item.1.dests %}
+{% for dest in item.value.dests %}
 
 [BridgeFDB]
 MACAddress=00:00:00:00:00:00


### PR DESCRIPTION
Currently the definition for vxlans is an array of mappings where the index and the value of the name key form the name of the networkd unit's file. Any change to the order of the array will result in a leaked unit with the old index, which is unexpected from a user's perspective and needs to be cleaned up.
The name already needs to be unique, since it is used as the interface's name. Therefore the structure could also be a mapping using the name as keys and filename, e.g.:

```
network_vxlan_interfaces:
  vxlan0:
    vni: ..
    local_ip: ..
    ..
  vxlan1:
    ...
```

This ensures unique interface names, which are also usable as filenames. Changing an interface name would still leak a file with the old name, but that would be expected when deleting resources from ansible.