### PR TITLE
network: add MACAddress to vxlan netdev

### DIFF
--- a/roles/network/templates/vxlan.netdev.j2
+++ b/roles/network/templates/vxlan.netdev.j2
@@ -2,6 +2,7 @@
 Name={{ item.key }}
 Kind=vxlan
 MTUBytes={{ item.value.mtu | default(1500) }}
+MACAddress={{ item.value.macaddress | default('none') }}
 
 [VXLAN]
 VNI={{ item.value.vni }}


### PR DESCRIPTION
Specifies the MAC address to use for the device, or takes the special value "none". When "none", systemd-networkd does not request the MAC address for the device, and the kernel will assign a random MAC address.