### PR TITLE
operator: add operator_environment param for custom env variables

### DIFF
--- a/roles/operator/defaults/main.yml
+++ b/roles/operator/defaults/main.yml
@@ -22,3 +22,5 @@ operator_sudo_nopasswd: true
 
 operator_sudo_cmd_list:
   - ALL
+
+operator_environment: {}

--- a/roles/operator/tasks/main.yml
+++ b/roles/operator/tasks/main.yml
@@ -53,6 +53,16 @@
     - "export LANG=C.UTF-8"
     - "export LC_ALL=C.UTF-8"
 
+- name: Set custom environment variables in .bashrc configuration file
+  become: true
+  ansible.builtin.lineinfile:
+    dest: "{{ result_create_operator_user.home }}/.bashrc"
+    line: "export {{ item.key }}={{ item.value }}"
+    create: true
+    mode: 0640
+  loop: "{{ operator_environment | dict2items }}"
+  when: operator_environment is defined and operator_environment
+
 - name: Create .ssh directory
   become: true
   ansible.builtin.file:


### PR DESCRIPTION
Add support for defining custom environment variables for the operator user through the operator_environment parameter. Defaults to empty dictionary to maintain backward compatibility.

AI-assisted: Claude Code