### PR TITLE
network: allow providing netplan configuration template via variable

### DIFF
--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -90,6 +90,11 @@ network_interface_restart_commands:
 
 # configuration for type netplan
 
+# Set network_netplan_config_template to provide the complete netplan configuration
+# as a Jinja2 template from a variable (e.g. injected via Netbox config context).
+# When defined, this takes precedence over the default template.
+# network_netplan_config_template:
+
 network_netplan_path: "/etc/netplan"
 network_netplan_file: "01-osism.yaml"
 network_netplan_permissions: 0600

--- a/roles/network/tasks/netplan-Debian-family.yml
+++ b/roles/network/tasks/netplan-Debian-family.yml
@@ -24,40 +24,71 @@
   with_items:
     - "{{ network_netplan_path }}"
 
-# NOTE: The use of the local actions are a workaround to allow
-#       the use of variables as keys in the dictionaries.
-
-- name: Prepare netplan configuration template
-  ansible.builtin.template:
-    src: netplan/01-osism.yaml.j2
-    dest: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
-    mode: 0644
-  delegate_to: localhost
-  # NOTE: This task does not change anything on the target host and always
-  #       changes. Regardless of whether changes really take place. Therefore
-  #       changed_when is set to False here.
+- name: Write network_netplan_config_template to temporary file
+  ansible.builtin.copy:
+    content: "{{ network_netplan_config_template }}"
+    dest: "/tmp/.network_netplan_config_template_{{ inventory_hostname }}.j2"
+    mode: 0600
   changed_when: false
+  delegate_to: localhost
+  when: network_netplan_config_template is defined
 
-- name: Copy netplan configuration
+- name: Render netplan configuration from network_netplan_config_template variable
   become: true
   ansible.builtin.template:
-    src: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+    src: "/tmp/.network_netplan_config_template_{{ inventory_hostname }}.j2"
     dest: "{{ network_netplan_path }}/{{ network_netplan_file }}"
     mode: 0600
     owner: root
     group: root
   notify:
     - Netplan configuration changed
+  when: network_netplan_config_template is defined
 
-- name: Remove netplan configuration template
+- name: Remove temporary network_netplan_config_template file
   ansible.builtin.file:
-    path: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+    path: "/tmp/.network_netplan_config_template_{{ inventory_hostname }}.j2"
     state: absent
-  delegate_to: localhost
-  # NOTE: This task does not change anything on the target host and always
-  #       changes. Regardless of whether changes really take place. Therefore
-  #       changed_when is set to False here.
   changed_when: false
+  delegate_to: localhost
+  when: network_netplan_config_template is defined
+
+# NOTE: The use of the local actions are a workaround to allow
+#       the use of variables as keys in the dictionaries.
+
+- when: network_netplan_config_template is not defined
+  block:  # noqa osism-fqcn
+    - name: Prepare netplan configuration template
+      ansible.builtin.template:
+        src: netplan/01-osism.yaml.j2
+        dest: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+        mode: 0644
+      delegate_to: localhost
+      # NOTE: This task does not change anything on the target host and always
+      #       changes. Regardless of whether changes really take place. Therefore
+      #       changed_when is set to False here.
+      changed_when: false
+
+    - name: Copy netplan configuration
+      become: true
+      ansible.builtin.template:
+        src: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+        dest: "{{ network_netplan_path }}/{{ network_netplan_file }}"
+        mode: 0600
+        owner: root
+        group: root
+      notify:
+        - Netplan configuration changed
+
+    - name: Remove netplan configuration template
+      ansible.builtin.file:
+        path: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+        state: absent
+      delegate_to: localhost
+      # NOTE: This task does not change anything on the target host and always
+      #       changes. Regardless of whether changes really take place. Therefore
+      #       changed_when is set to False here.
+      changed_when: false
 
 # NOTE: On pure netplan systems, /etc/network as directory might just not exists
 - name: Check if path for interface file exists

--- a/roles/network/tasks/netplan-RedHat-family.yml
+++ b/roles/network/tasks/netplan-RedHat-family.yml
@@ -17,40 +17,71 @@
   with_items:
     - "{{ network_netplan_path }}"
 
-# NOTE: The use of the local actions are a workaround to allow
-#       the use of variables as keys in the dictionaries.
-
-- name: Prepare netplan configuration template
-  ansible.builtin.template:
-    src: netplan/01-osism.yaml.j2
-    dest: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
-    mode: 0644
-  delegate_to: localhost
-  # NOTE: This task does not change anything on the target host and always
-  #       changes. Regardless of whether changes really take place. Therefore
-  #       changed_when is set to False here.
+- name: Write network_netplan_config_template to temporary file
+  ansible.builtin.copy:
+    content: "{{ network_netplan_config_template }}"
+    dest: "/tmp/.network_netplan_config_template_{{ inventory_hostname }}.j2"
+    mode: 0600
   changed_when: false
+  delegate_to: localhost
+  when: network_netplan_config_template is defined
 
-- name: Copy netplan configuration
+- name: Render netplan configuration from network_netplan_config_template variable
   become: true
   ansible.builtin.template:
-    src: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+    src: "/tmp/.network_netplan_config_template_{{ inventory_hostname }}.j2"
     dest: "{{ network_netplan_path }}/{{ network_netplan_file }}"
     mode: 0600
     owner: root
     group: root
   notify:
     - Netplan configuration changed
+  when: network_netplan_config_template is defined
 
-- name: Remove netplan configuration template
+- name: Remove temporary network_netplan_config_template file
   ansible.builtin.file:
-    path: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+    path: "/tmp/.network_netplan_config_template_{{ inventory_hostname }}.j2"
     state: absent
-  delegate_to: localhost
-  # NOTE: This task does not change anything on the target host and always
-  #       changes. Regardless of whether changes really take place. Therefore
-  #       changed_when is set to False here.
   changed_when: false
+  delegate_to: localhost
+  when: network_netplan_config_template is defined
+
+# NOTE: The use of the local actions are a workaround to allow
+#       the use of variables as keys in the dictionaries.
+
+- when: network_netplan_config_template is not defined
+  block:  # noqa osism-fqcn
+    - name: Prepare netplan configuration template
+      ansible.builtin.template:
+        src: netplan/01-osism.yaml.j2
+        dest: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+        mode: 0644
+      delegate_to: localhost
+      # NOTE: This task does not change anything on the target host and always
+      #       changes. Regardless of whether changes really take place. Therefore
+      #       changed_when is set to False here.
+      changed_when: false
+
+    - name: Copy netplan configuration
+      become: true
+      ansible.builtin.template:
+        src: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+        dest: "{{ network_netplan_path }}/{{ network_netplan_file }}"
+        mode: 0600
+        owner: root
+        group: root
+      notify:
+        - Netplan configuration changed
+
+    - name: Remove netplan configuration template
+      ansible.builtin.file:
+        path: "/tmp/{{ inventory_hostname }}-01-osism.yaml.j2"
+        state: absent
+      delegate_to: localhost
+      # NOTE: This task does not change anything on the target host and always
+      #       changes. Regardless of whether changes really take place. Therefore
+      #       changed_when is set to False here.
+      changed_when: false
 
 # NOTE: On pure netplan systems, /etc/network as directory might just not exists
 - name: Check if path for interface file exists


### PR DESCRIPTION
Add support for network_netplan_config_template variable to provide the complete netplan configuration as a Jinja2 template from an external source like Netbox config context. This enables deployments where the config repository cannot be modified (e.g. on metalbox environments).

AI-assisted: Claude Code