### PR TITLE
network: name block tasks in netplan task files

### DIFF
--- a/roles/network/tasks/netplan-Debian-family.yml
+++ b/roles/network/tasks/netplan-Debian-family.yml
@@ -56,7 +56,8 @@
 # NOTE: The use of the local actions are a workaround to allow
 #       the use of variables as keys in the dictionaries.
 
-- when: network_netplan_config_template is not defined
+- name: Render default netplan configuration
+  when: network_netplan_config_template is not defined
   block:  # noqa osism-fqcn
     - name: Prepare netplan configuration template
       ansible.builtin.template:

--- a/roles/network/tasks/netplan-RedHat-family.yml
+++ b/roles/network/tasks/netplan-RedHat-family.yml
@@ -49,7 +49,8 @@
 # NOTE: The use of the local actions are a workaround to allow
 #       the use of variables as keys in the dictionaries.
 
-- when: network_netplan_config_template is not defined
+- name: Render default netplan configuration
+  when: network_netplan_config_template is not defined
   block:  # noqa osism-fqcn
     - name: Prepare netplan configuration template
       ansible.builtin.template:


### PR DESCRIPTION
Fixes ansible-lint name[missing] violations on the conditional blocks that render the default netplan configuration.

AI-assisted: Claude Code