### PR TITLE
Fix black 26.3.1 formatting

### DIFF
--- a/molecule/delegated/tests/docker_compose.py
+++ b/molecule/delegated/tests/docker_compose.py
@@ -63,9 +63,7 @@ def test_wrapper_file(host):
     assert f.exists
     assert f.is_file
     assert f.mode == 0o755
-    assert (
-        f.content_string.strip()
-        == """#!/usr/bin/env bash
+    assert f.content_string.strip() == """#!/usr/bin/env bash
 
 # The docker-compose CLI has been removed in OSISM.
 # The Compose plugin for Docker is now used.
@@ -73,7 +71,6 @@ def test_wrapper_file(host):
 
 /usr/bin/docker compose "$@"
 """.strip()
-    )
 
 
 def test_docker_compose_installation(host):

--- a/plugins/callback/still_alive.py
+++ b/plugins/callback/still_alive.py
@@ -6,7 +6,6 @@ import time
 
 from ansible.plugins.callback.default import CallbackModule as Default
 
-
 __metaclass__ = type
 
 DOCUMENTATION = """


### PR DESCRIPTION
## Summary
- Reformat code to comply with black 26.3.1 stable style (updated in osism/zuul-jobs#180)

## Test plan
- [ ] python-black Zuul job passes