### PR TITLE
sosreport: drop become for local archive directory creation

### DIFF
--- a/molecule/delegated/vars/sosreport.yml
+++ b/molecule/delegated/vars/sosreport.yml
@@ -1,3 +1,5 @@
 ---
 operator_user: zuul
 operator_group: zuul
+
+sosreport_archive_directory: /tmp/archive

--- a/roles/sosreport/tasks/main.yml
+++ b/roles/sosreport/tasks/main.yml
@@ -20,7 +20,6 @@
     mode: 0755
 
 - name: Create local required directories
-  become: true
   ansible.builtin.file:
     path: "{{ sosreport_archive_directory }}"
     state: directory


### PR DESCRIPTION
The "Create local required directories" task is delegated to localhost, so escalating privileges on the control node is unnecessary and forces sudo where it shouldn't be needed.

Closes osism/issues#1359