### PR TITLE
sosreport: fix file existence checks and invalid fetch parameter

### DIFF
--- a/roles/sosreport/tasks/main.yml
+++ b/roles/sosreport/tasks/main.yml
@@ -79,7 +79,6 @@
     src: "{{ sosreport_tmpdir }}/{{ sosreport_archive_filename }}.sha256"
     dest: "{{ sosreport_archive_directory }}/{{ sosreport_archive_filename }}.sha256"
     flat: true
-    change: true
   when: file_sha256.files | length > 0
 
 - name: Fetch md5 file
@@ -87,7 +86,6 @@
     src: "{{ sosreport_tmpdir }}/{{ sosreport_archive_filename }}.md5"
     dest: "{{ sosreport_archive_directory }}/{{ sosreport_archive_filename }}.md5"
     flat: true
-    change: true
   when: file_md5.files | length > 0
 
 - name: Fetch archive
@@ -95,7 +93,6 @@
     src: "{{ sosreport_tmpdir }}/{{ sosreport_archive_filename }}"
     dest: "{{ sosreport_archive_directory }}/{{ sosreport_archive_filename }}"
     flat: true
-    change: true
 
 - name: Create archive directory
   ansible.builtin.file:

--- a/roles/sosreport/tasks/main.yml
+++ b/roles/sosreport/tasks/main.yml
@@ -36,26 +36,28 @@
   changed_when: true
 
 - name: Check if sha256 file exists
-  ansible.builtin.stat:
-    path: "/path/to/files/*.sha256"
+  ansible.builtin.find:
+    paths: "{{ sosreport_tmpdir }}"
+    patterns: "*.sha256"
   register: file_sha256
 
 - name: Rename sha256 file
   become: true
   ansible.builtin.shell: "mv -f {{ sosreport_tmpdir }}/*.sha256 {{ sosreport_tmpdir }}/{{ sosreport_archive_filename }}.sha256"
   changed_when: true
-  when: file_sha256.stat.exists
+  when: file_sha256.files | length > 0
 
 - name: Check if md5 file exists
-  ansible.builtin.stat:
-    path: "/path/to/files/*.md5"
+  ansible.builtin.find:
+    paths: "{{ sosreport_tmpdir }}"
+    patterns: "*.md5"
   register: file_md5
 
 - name: Rename md5 file
   become: true
   ansible.builtin.shell: "mv -f {{ sosreport_tmpdir }}/*.md5 {{ sosreport_tmpdir }}/{{ sosreport_archive_filename }}.md5"
   changed_when: true
-  when: file_md5.stat.exists
+  when: file_md5.files | length > 0
 
 - name: Rename archive
   become: true
@@ -78,7 +80,7 @@
     dest: "{{ sosreport_archive_directory }}/{{ sosreport_archive_filename }}.sha256"
     flat: true
     change: true
-  when: file_sha256.stat.exists
+  when: file_sha256.files | length > 0
 
 - name: Fetch md5 file
   ansible.builtin.fetch:
@@ -86,7 +88,7 @@
     dest: "{{ sosreport_archive_directory }}/{{ sosreport_archive_filename }}.md5"
     flat: true
     change: true
-  when: file_md5.stat.exists
+  when: file_md5.files | length > 0
 
 - name: Fetch archive
   ansible.builtin.fetch:


### PR DESCRIPTION
## Summary

- Replace `ansible.builtin.stat` (with non-functional glob/placeholder paths) with `ansible.builtin.find` for the sha256 and md5 file existence checks before renaming
- Update `when` conditions from `file_sha256.stat.exists` to `file_sha256.files | length > 0` to match the `find` module's return structure
- Remove invalid `change: true` module parameter from the three `ansible.builtin.fetch` tasks; the `fetch` module reports accurate change status based on file checksums without it

The practical impact of the first fix: the archive itself was always fetched correctly (the `Fetch archive` task has no `when` guard), but the sha256 and md5 checksum files were never renamed or fetched — they were left in `sosreport_tmpdir` under their auto-generated names and deleted when the temporary directory was cleaned up. The role reported success throughout, so the loss of integrity verification files went unnoticed.

The `change: true` issue was confirmed as silently ignored (not a hard failure) via Zuul CI logs for PR #850.

## Test plan

- [ ] Zuul molecule job passes for this role
- [ ] Verify sha256 and md5 files are fetched to `sosreport_archive_directory` alongside the archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)