### PR TITLE
ansible: drop obsolete osism-fqcn noqa on blocks

### DIFF
--- a/roles/network/tasks/netplan-Debian-family.yml
+++ b/roles/network/tasks/netplan-Debian-family.yml
@@ -58,7 +58,7 @@
 
 - name: Render default netplan configuration
   when: network_netplan_config_template is not defined
-  block:  # noqa osism-fqcn
+  block:
     - name: Prepare netplan configuration template
       ansible.builtin.template:
         src: netplan/01-osism.yaml.j2

--- a/roles/network/tasks/netplan-RedHat-family.yml
+++ b/roles/network/tasks/netplan-RedHat-family.yml
@@ -51,7 +51,7 @@
 
 - name: Render default netplan configuration
   when: network_netplan_config_template is not defined
-  block:  # noqa osism-fqcn
+  block:
     - name: Prepare netplan configuration template
       ansible.builtin.template:
         src: netplan/01-osism.yaml.j2

--- a/roles/trivy/tasks/install-Debian-family.yml
+++ b/roles/trivy/tasks/install-Debian-family.yml
@@ -1,6 +1,6 @@
 ---
 - name: Trivy installation
-  block:  # noqa osism-fqcn
+  block:
     - name: Remove old architecture-dependent repository
       become: true
       ansible.builtin.apt_repository:

--- a/roles/user/tasks/remote-key.yml
+++ b/roles/user/tasks/remote-key.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get and set remote SSH authorized keys
   when: item.key.startswith('https') or item.key == "github"
-  block:  # noqa: osism-fqcn
+  block:
     - name: Fetch SSH authorized key
       ansible.builtin.uri:
         url: "{{ item.key }}"


### PR DESCRIPTION
## Summary

The custom `osism-fqcn` ansible-lint rule previously emitted spurious violations on `block`/`rescue`/`always` constructs. osism/container-images#902 fixed the rule and the updated `ansible-lint` image has been published, so the `# noqa osism-fqcn` workarounds on these block constructs are now obsolete false-positive suppressions.

This removes those obsolete annotations from the four affected `block:` lines:

- `roles/network/tasks/netplan-Debian-family.yml`
- `roles/network/tasks/netplan-RedHat-family.yml`
- `roles/trivy/tasks/install-Debian-family.yml`
- `roles/user/tasks/remote-key.yml`

`roles/limits/tasks/limits.yml` was intentionally left untouched: its `# noqa osism-fqcn` sits on a real module (`community.general.pam_limits`) and is a genuine suppression that must stay.

This is part of the sweep tracked in osism/issues#1368.

Related-Bug: #1368