### PR TITLE
Remove dead scan_services mock_modules entry

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,4 @@
 ---
-mock_modules:
-  - scan_services
 skip_list:
   - var-naming[no-role-prefix]
   - package-latest


### PR DESCRIPTION
`scan_services` is mocked in `.ansible-lint` but is not referenced anywhere in the repository — dead configuration.

Newer ansible-core (in the current `ansible-lint` image) no longer lets bare `mock_modules` satisfy the syntax-check phase, so bare mocks are being retired across OSISM repos. Removing this unused one keeps the repo off the broken mechanism. Verified against the `ansible-lint` image: lint still passes clean without it.

Related:

- osism/issues#1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)