### PR TITLE
roles: fix non-boolean when: conditionals for ansible-core 2.19

### DIFF
--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -4,7 +4,7 @@
   when:
     - proxy_enable | bool
     - proxy_package_manager | bool
-    - proxy_proxies
+    - proxy_proxies | length > 0
 
 - name: Set system wide settings in environment file
   become: true
@@ -28,7 +28,7 @@
       NO_PROXY={{ proxy_no_proxy | join(',') }}
   when:
     - proxy_enable | bool
-    - proxy_proxies
+    - proxy_proxies | length > 0
 
 - name: Remove system wide settings in environment file
   become: true
@@ -38,4 +38,4 @@
     state: absent
   when:
     - proxy_enable | bool
-    - not proxy_proxies
+    - proxy_proxies | length == 0

--- a/roles/repository/tasks/Debian.yml
+++ b/roles/repository/tasks/Debian.yml
@@ -26,7 +26,7 @@
       repository as files and set the repository_key_files_directory parameter
       (e.g. /opt/configuration/files/repository_keys).
   when:
-    - repository_key_ids
+    - repository_key_ids | length > 0
 
 # We ignore errors that can occur during the seeding of the
 # environment in constellations where the repository keys are


### PR DESCRIPTION
ansible-core 2.19 requires every `when:` expression to evaluate to a real
boolean and aborts the task otherwise (`Conditional result ... was derived
from value of type 'dict'. Conditionals must have a boolean result`). Two
roles gated tasks on a dict variable directly, which worked by dict
truthiness on <= 2.18 but breaks under 2.19.

- **proxy**: `proxy_proxies` (a dict) drove three `when:` sites — replaced
  with explicit `| length > 0` / `| length == 0`, preserving semantics.
- **repository**: `repository_key_ids` (a dict) drove the keyserver guard —
  replaced with `| length > 0`.

Prep for moving `ansible_molecule_ansible_version` to 12.x (ansible-core
2.19); no functional change on the currently pinned 11.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)