### PR TITLE
zuul: bump molecule ansible test pin to 12.3.0

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -95,7 +95,7 @@
         - name: ubuntu-noble
           label: ubuntu-noble
     vars:
-      ansible_molecule_ansible_version: "11.13.0"
+      ansible_molecule_ansible_version: "12.3.0"
     files:
       - '^\.zuul\.yaml$'
       - '^molecule\/delegated\/[^\/]*yml$'


### PR DESCRIPTION
Advance `ansible_molecule_ansible_version` 11.13.0 → 12.3.0 (ansible-core
2.19), matching `ansible-collection-validations` and exercising the
collection against a newer ansible than the 11.x runtime as a forward-compat
canary. 12.3.0 is the ceiling that still installs on the debian-bookworm
test node (Python 3.11).

Draft — depends on the ansible-core 2.19 role fixes; merge that first or the
proxy/repository molecule jobs fail on non-boolean conditionals:

- osism/ansible-collection-commons#866

Part of:

- osism/issues#1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)
