### PR TITLE
proxy: make apt conditional boolean

### DIFF
--- a/roles/proxy/tasks/Debian-family.yml
+++ b/roles/proxy/tasks/Debian-family.yml
@@ -7,4 +7,4 @@
     owner: root
     group: root
     mode: 0644
-  when: proxy_proxies
+  when: proxy_proxies | length > 0


### PR DESCRIPTION
Follow-up to #866, which converted the bare `proxy_proxies` dict tests to
explicit length checks so `when:` expressions evaluate to a real boolean under
ansible-core 2.19. It covered the three occurrences in `tasks/main.yml` but
missed the fourth in `tasks/Debian-family.yml`.

The role therefore still aborts on Debian hosts as soon as a proxy is
configured — `main.yml` gates the `include_tasks` correctly, and the included
apt task then fails:

```
TASK [osism.commons.proxy : Configure proxy parameters for apt]
[ERROR]: Task failed: Conditional result (True) was derived from value of
type 'dict'. Conditionals must have a boolean result.
  when: proxy_proxies
```

Apply the same `| length > 0` check here. The gate is redundant with the
`include_tasks` condition in `main.yml`, but keeping it consistent leaves the
file safe when included directly.

Part of:

- osism/issues#1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)