### PR TITLE
docker_login: add a second login as the operator user

### DIFF
--- a/molecule/delegated/tests/docker_login.py
+++ b/molecule/delegated/tests/docker_login.py
@@ -1,4 +1,6 @@
-from .util.util import get_ansible
+import json
+
+from .util.util import get_ansible, get_variable
 
 testinfra_runner, testinfra_hosts = get_ansible()
 
@@ -15,4 +17,28 @@ def test_packages_installed(host):
     assert pass_pkg.is_installed, "The pass package is not installed."
 
 
-# The actual login is done by the role itself so we don't explicitly test this here again.
+def _assert_login(host, user):
+    """Check that the credentials of the registry are stored for a user."""
+
+    registry = get_variable(host, "docker_login_registry")
+
+    with host.sudo(user):
+        home = host.user(user).home
+        config = host.file(f"{home}/.docker/config.json")
+
+        assert config.exists, f"No docker configuration file for the user {user}."
+        assert registry in json.loads(config.content_string).get(
+            "auths", {}
+        ), f"No credentials for the registry {registry} for the user {user}."
+
+
+def test_login_as_root(host):
+    """Check that the login was done for the root user."""
+
+    _assert_login(host, "root")
+
+
+def test_login_as_operator(host):
+    """Check that the login was done for the operator user."""
+
+    _assert_login(host, get_variable(host, "docker_login_operator_user"))

--- a/molecule/delegated/vars/docker_login.yml
+++ b/molecule/delegated/vars/docker_login.yml
@@ -2,3 +2,4 @@
 docker_login_registry: 127.0.0.1:5000
 docker_login_username: testuser123
 docker_login_password: dockerpassword123
+docker_login_operator_user: zuul

--- a/roles/docker_login/defaults/main.yml
+++ b/roles/docker_login/defaults/main.yml
@@ -16,3 +16,18 @@ docker_login_username:
 # Required: This parameter must be set for authentication to work
 # Security: Store this value securely (e.g., in Ansible Vault)
 docker_login_password:
+
+# Perform the login as the root user
+# Container images that are pulled with privilege escalation (e.g. by
+# Kolla) use the credentials stored for the root user.
+docker_login_as_root: true
+
+# Perform the login as the operator user
+# Container images that are pulled without privilege escalation (e.g. by
+# the manager service) use the credentials stored for the operator user.
+# The operator user has to exist and has to be a member of the docker group.
+docker_login_as_operator: true
+
+# Operator user the login is performed as when docker_login_as_operator is
+# enabled
+docker_login_operator_user: "{{ operator_user | default('dragon') }}"

--- a/roles/docker_login/tasks/main.yml
+++ b/roles/docker_login/tasks/main.yml
@@ -19,10 +19,21 @@
     lock_timeout: "{{ apt_lock_timeout | default(300) }}"
   when: ansible_os_family == "Debian"
 
-- name: Login to registry and force re-authorization
+- name: Login to registry and force re-authorization as the root user
   become: true
   community.docker.docker_login:
     registry: "{{ docker_login_registry }}"
     username: "{{ docker_login_username }}"
     password: "{{ docker_login_password }}"
     reauthorize: true
+  when: docker_login_as_root | bool
+
+- name: Login to registry and force re-authorization as the operator user
+  become: true
+  become_user: "{{ docker_login_operator_user }}"
+  community.docker.docker_login:
+    registry: "{{ docker_login_registry }}"
+    username: "{{ docker_login_username }}"
+    password: "{{ docker_login_password }}"
+    reauthorize: true
+  when: docker_login_as_operator | bool


### PR DESCRIPTION
Fixes the inconsistency reported in https://github.com/osism/issues/issues/1442.

The role logged in with `become: true` only, which stores the registry credentials in `/root/.docker/config.json`. Container images are pulled without privilege escalation though — the manager role's `Pull container images` task runs as the operator user — so the pull fails against a private registry even after a successful `docker-login` run.

## Changes

* `roles/docker_login/tasks/main.yml`: a second login as the operator user (`become_user`), so the credentials end up in `/home/dragon/.docker/config.json` as well.
* `roles/docker_login/defaults/main.yml`: three new parameters.
  * `docker_login_as_root` (default `true`) — the previous behaviour, now switchable.
  * `docker_login_as_operator` (default `true`) — the new login.
  * `docker_login_operator_user` (default `{{ operator_user | default('dragon') }}`).
* `molecule/delegated/`: the delegated scenario has no `dragon` user, so `docker_login_operator_user` is set to `zuul` there; the testinfra tests now check that `~/.docker/config.json` exists and carries an `auths` entry for the registry, for both root and the operator user.

## Notes

Both logins default to enabled. The root login keeps its previous behaviour, and the operator login is what makes the pulls work out of the box — with it disabled by default the reported bug would persist for everyone.

The second login requires the operator user to exist and to be a member of the docker group. In OSISM the `operator` role guarantees that; for other users of the collection `docker_login_as_operator: false` is the way out. This is documented in the defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)